### PR TITLE
Build SPA hub for Ceradon Architect stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Ceradon-Architect
+# Ceradon Architect Stack Hub
+
+This repo is the front-door, static SPA hub for the Ceradon Architect tools, published via GitHub Pages at <https://nbschultz97.github.io/Ceradon-Architect/>. It links to the live module apps and explains the integrated planning workflow.
+
+## Quick start
+- Serve locally with any static file host (e.g., `python -m http.server 8000`) and open `http://localhost:8000`.
+- Navigate with hash routes: `/#/home`, `/#/workflow`, `/#/tools`, `/#/mission`, `/#/demos`, `/#/docs`.
+- Use the light/dark toggle in the nav to switch themes.
+
+## Updating content
+- **Theme tokens:** edit `assets/css/styles.css` (`:root` and `[data-theme="light"]`).
+- **Routes & views:** sections live in `index.html`; routing is in `assets/js/app.js`.
+- **Tools:** update the `toolData` array in `assets/js/app.js` to add or change tool cards.
+- **Workflow modes:** adjust the `workflowModes` array in `assets/js/app.js`.
+- **Demo stories:** edit the `demoStories` array in `assets/js/app.js`.
+- **Mission Architect embed:** update the iframe/link URL in the `mission` section of `index.html`.
+
+## Tool deep links
+- Node Architect: <https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html>
+- UxS Architect: <https://nbschultz97.github.io/Ceradon-UxS-Architect/web/>
+- Mesh Architect: <https://nbschultz97.github.io/Ceradon-Mesh-Architect/>
+- KitSmith: <https://nbschultz97.github.io/Ceradon-KitSmith/>
+- Mission Architect: <https://nbschultz97.github.io/Mission-Architect/>
+
+## Notes
+- The site is fully static and GitHub Pages–compatible; no backend or build tooling is required.
+- Mission Architect already exists as its own app and is integrated via links/iframe only.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,432 @@
+:root {
+  --bg: #0f131a;
+  --panel: #161c25;
+  --card: #1c2430;
+  --border: #273142;
+  --text: #e6eefc;
+  --muted: #9fb1c9;
+  --accent: #4da3ff;
+  --accent-strong: #6ec1ff;
+  --shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="light"] {
+  --bg: #f6f8fb;
+  --panel: #ffffff;
+  --card: #f1f4f8;
+  --border: #d9e2ec;
+  --text: #0f1722;
+  --muted: #4a5568;
+  --accent: #2b6cb0;
+  --accent-strong: #3182ce;
+  --shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--accent-strong);
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 24px;
+  background: rgba(15, 19, 26, 0.92);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+
+.logo-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  box-shadow: 0 0 12px rgba(77, 163, 255, 0.6);
+}
+
+.nav-links {
+  display: flex;
+  gap: 16px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-links a {
+  padding: 8px 12px;
+  border-radius: 8px;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible,
+.nav-links a.active {
+  background: var(--panel);
+  color: var(--accent);
+  border: 1px solid var(--border);
+}
+
+.toggle {
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--text);
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.toggle:hover,
+.toggle:focus-visible {
+  border-color: var(--accent);
+}
+
+.view-container {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px 20px 80px;
+}
+
+.section-header {
+  display: flex;
+  gap: 32px;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+  color: var(--muted);
+  margin: 0 0 8px;
+}
+
+h1, h2, h3, h4 {
+  color: var(--text);
+  margin: 8px 0;
+}
+
+.lead {
+  color: var(--muted);
+  max-width: 760px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+.hero-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 18px;
+  box-shadow: var(--shadow);
+}
+
+.stack-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.stack-list li {
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--card);
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  color: var(--text);
+  background: var(--panel);
+  text-decoration: none;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #0c111a;
+  border: none;
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: var(--border);
+}
+
+.btn.subtle {
+  background: var(--card);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(77, 163, 255, 0.2);
+}
+
+.card-grid,
+.tool-grid,
+.demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.card,
+.tool-card,
+.embed-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.card:hover,
+.tool-card:hover,
+.embed-card:hover {
+  border-color: var(--accent);
+}
+
+.tool-card.highlight {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(77, 163, 255, 0.25);
+}
+
+.tool-card .badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.badge {
+  background: var(--card);
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  border-radius: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.status {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  align-self: flex-start;
+}
+
+.status.live { color: #2dd4bf; border-color: #2dd4bf33; }
+.status.prototype { color: #fbbf24; border-color: #fbbf2433; }
+.status.planned { color: #f87171; border-color: #f8717133; }
+
+.workflow-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.workflow-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 10px;
+}
+
+.workflow-card button,
+.workflow-card a {
+  justify-self: flex-start;
+}
+
+.loop-diagram {
+  position: relative;
+  width: 280px;
+  height: 280px;
+  display: grid;
+  place-items: center;
+}
+
+.loop-node {
+  position: absolute;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  text-align: center;
+  width: 110px;
+}
+
+.loop-node:nth-child(1) { top: 10px; left: 50%; transform: translateX(-50%); }
+.loop-node:nth-child(2) { left: 10px; top: 90px; }
+.loop-node:nth-child(3) { right: 10px; top: 90px; }
+.loop-node:nth-child(4) { left: 30px; bottom: 40px; }
+.loop-node:nth-child(5) { right: 30px; bottom: 40px; }
+
+.loop-lines {
+  width: 100%;
+  height: 100%;
+  fill: none;
+  stroke: var(--border);
+  stroke-width: 2;
+}
+
+.mission-layout,
+.docs-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.bullet-list {
+  padding-left: 18px;
+  color: var(--muted);
+}
+
+.sample-flow ol {
+  margin: 8px 0 12px 18px;
+}
+
+.quick-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.embed-container {
+  position: relative;
+  width: 100%;
+  padding-top: 60%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--card);
+}
+
+.embed-container iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.demo-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 10px;
+}
+
+.demo-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tool-card h3,
+.workflow-card h3,
+.demo-card h3,
+.embed-card h3,
+.card h3 {
+  margin-bottom: 0;
+}
+
+.small {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: 20px;
+  background: var(--panel);
+  text-align: center;
+  color: var(--muted);
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+@media (max-width: 760px) {
+  .nav-links {
+    display: none;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .loop-diagram {
+    width: 220px;
+    height: 220px;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,277 @@
+// Ceradon Architect SPA
+// - Hash-based routes: home, workflow, tools, mission, demos, docs
+// - Theme tokens live in assets/css/styles.css
+// - Add new tools/demos by editing the data blocks below
+
+const toolData = [
+  {
+    name: 'Mission Architect',
+    type: 'Mission composition',
+    description: 'Mission-first entry point for phases, AO geometry, and constraints that drive the rest of the stack.',
+    status: 'Live demo',
+    badges: ['Mission composition', 'JSON export'],
+    link: 'https://nbschultz97.github.io/Mission-Architect/'
+  },
+  {
+    name: 'Node Architect',
+    type: 'Planning tool',
+    description: 'Define sensing nodes, payload stacks, power envelopes, and deployment conditions.',
+    status: 'Live demo',
+    badges: ['Node planning', 'Payload design'],
+    link: 'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html'
+  },
+  {
+    name: 'UxS Architect',
+    type: 'Planning tool',
+    description: 'Pair nodes to UxS platforms (air/ground/surface) with loadouts and sortie timing.',
+    status: 'Live demo',
+    badges: ['Platform design', 'Loadouts'],
+    link: 'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/'
+  },
+  {
+    name: 'Mesh Architect',
+    type: 'RF tool',
+    description: 'Shape RF meshes, relays, and gateways for contested environments.',
+    status: 'Live demo',
+    badges: ['Mesh / RF', 'Coverage'],
+    link: 'https://nbschultz97.github.io/Ceradon-Mesh-Architect/'
+  },
+  {
+    name: 'KitSmith',
+    type: 'Planning tool',
+    description: 'Build kits, spares, and sustainment loads aligned to mission phases and roles.',
+    status: 'Live demo',
+    badges: ['Kits & sustainment', 'Resupply'],
+    link: 'https://nbschultz97.github.io/Ceradon-KitSmith/'
+  }
+];
+
+const workflowModes = [
+  {
+    name: 'Mission-first',
+    primary: ['Mission Architect'],
+    secondary: ['Node Architect', 'UxS Architect', 'Mesh Architect', 'KitSmith'],
+    description: 'Start with AO, phases, and constraints. Push node packages, platform pairings, meshes, and kits from mission exports.',
+    scenario: 'Recon-in-force across two phases with RF denied windows.',
+    action: { label: 'Open Mission Architect', link: 'https://nbschultz97.github.io/Mission-Architect/' }
+  },
+  {
+    name: 'Inventory-first',
+    primary: ['Node Architect', 'UxS Architect'],
+    secondary: ['Mesh Architect', 'KitSmith', 'Mission Architect'],
+    description: 'Start from what you have on hand: payloads, radios, and platforms. Back-map to missions and sustainment.',
+    scenario: 'Inventory of five quads and mixed RF payloads, mapping to ISR tasks.',
+    action: { label: 'Highlight tools', link: '#/tools', highlight: ['Node Architect', 'UxS Architect'] }
+  },
+  {
+    name: 'Constraint-first',
+    primary: ['KitSmith'],
+    secondary: ['Mission Architect', 'Node Architect', 'UxS Architect', 'Mesh Architect'],
+    description: 'Lead with sustainment limits, team roles, and resupply cadence. Size missions and nodes to fit.',
+    scenario: '72-hour small team with cold weather sustainment and limited resupply.',
+    action: { label: 'Open KitSmith', link: 'https://nbschultz97.github.io/Ceradon-KitSmith/' }
+  },
+  {
+    name: 'RF-environment-first',
+    primary: ['Mesh Architect'],
+    secondary: ['Mission Architect', 'Node Architect', 'UxS Architect', 'KitSmith'],
+    description: 'Anchor on spectrum, terrain, and denial threats. Fit mission, platforms, and kits to viable RF paths.',
+    scenario: 'Dense urban block with limited LOS and heavy multipath.',
+    action: { label: 'Open Mesh Architect', link: 'https://nbschultz97.github.io/Ceradon-Mesh-Architect/' }
+  }
+];
+
+const demoStories = [
+  {
+    name: 'Cold-weather recon lane',
+    entry: 'Mission-first',
+    flow: 'Mission Architect → Node Architect → UxS Architect → Mesh Architect → KitSmith',
+    outputs: 'Mission phases with cold-weather sustainment, nodes with heaters, quad sorties, urban mesh, winter kits.',
+    links: {
+      mission: 'https://nbschultz97.github.io/Mission-Architect/',
+      tools: [
+        'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html',
+        'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/',
+        'https://nbschultz97.github.io/Ceradon-Mesh-Architect/',
+        'https://nbschultz97.github.io/Ceradon-KitSmith/'
+      ]
+    }
+  },
+  {
+    name: 'Urban mesh in dense city block',
+    entry: 'RF-environment-first',
+    flow: 'Mesh Architect → Mission Architect → Node Architect → UxS Architect → KitSmith',
+    outputs: 'RF survey-driven relays, mission phases constrained to coverage pockets, small quad loadouts, lean kits.',
+    links: {
+      mission: 'https://nbschultz97.github.io/Mission-Architect/',
+      tools: [
+        'https://nbschultz97.github.io/Ceradon-Mesh-Architect/',
+        'https://nbschultz97.github.io/Mission-Architect/',
+        'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html',
+        'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/',
+        'https://nbschultz97.github.io/Ceradon-KitSmith/'
+      ]
+    }
+  },
+  {
+    name: 'Inventory-driven kit refresh',
+    entry: 'Inventory-first',
+    flow: 'Node Architect → UxS Architect → Mission Architect → KitSmith → Mesh Architect',
+    outputs: 'Start with inventory, approve platforms, capture mission framing, right-size sustainment, then check RF links.',
+    links: {
+      mission: 'https://nbschultz97.github.io/Mission-Architect/',
+      tools: [
+        'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html',
+        'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/',
+        'https://nbschultz97.github.io/Mission-Architect/',
+        'https://nbschultz97.github.io/Ceradon-KitSmith/',
+        'https://nbschultz97.github.io/Ceradon-Mesh-Architect/'
+      ]
+    }
+  }
+];
+
+const routes = ['home', 'workflow', 'tools', 'mission', 'demos', 'docs'];
+let highlightedTools = [];
+
+function setActiveRoute(route) {
+  const target = routes.includes(route) ? route : 'home';
+
+  document.querySelectorAll('.view').forEach(section => {
+    section.hidden = section.id !== target;
+  });
+
+  document.querySelectorAll('.nav-links a').forEach(link => {
+    const isActive = link.dataset.route === target;
+    link.classList.toggle('active', isActive);
+  });
+}
+
+function handleHashChange() {
+  const hash = window.location.hash.replace('#/', '') || 'home';
+  setActiveRoute(hash);
+}
+
+function buildTools() {
+  const grid = document.getElementById('toolGrid');
+  grid.innerHTML = '';
+
+  toolData.forEach(tool => {
+    const card = document.createElement('article');
+    card.className = 'tool-card';
+    if (highlightedTools.includes(tool.name)) {
+      card.classList.add('highlight');
+    }
+    card.innerHTML = `
+      <div class="status ${tool.status.toLowerCase().replace(' ', '')}">${tool.status}</div>
+      <h3>${tool.name}</h3>
+      <p class="small">${tool.type}</p>
+      <p>${tool.description}</p>
+      <div class="badges">${tool.badges.map(b => `<span class="badge">${b}</span>`).join('')}</div>
+      <a class="btn primary" href="${tool.link}" target="_blank" rel="noopener">Open in new tab</a>
+    `;
+    grid.appendChild(card);
+  });
+}
+
+function buildWorkflows() {
+  const grid = document.getElementById('workflowModes');
+  grid.innerHTML = '';
+
+  workflowModes.forEach(mode => {
+    const card = document.createElement('div');
+    card.className = 'workflow-card';
+    card.innerHTML = `
+      <h3>${mode.name}</h3>
+      <p>${mode.description}</p>
+      <p class="small"><strong>Primary:</strong> ${mode.primary.join(', ')}</p>
+      <p class="small"><strong>Secondary:</strong> ${mode.secondary.join(', ')}</p>
+      <p class="small"><strong>Example:</strong> ${mode.scenario}</p>
+    `;
+    const action = document.createElement('a');
+    action.className = 'btn ghost';
+    action.textContent = mode.action.label;
+    action.href = mode.action.link;
+    if (!mode.action.link.startsWith('http')) {
+      action.addEventListener('click', (e) => {
+        e.preventDefault();
+        highlightedTools = mode.action.highlight || [];
+        buildTools();
+        window.location.hash = mode.action.link;
+      });
+    } else {
+      action.target = '_blank';
+      action.rel = 'noopener';
+    }
+    card.appendChild(action);
+    grid.appendChild(card);
+  });
+}
+
+function buildDemos() {
+  const grid = document.getElementById('demoGrid');
+  grid.innerHTML = '';
+
+  demoStories.forEach(demo => {
+    const card = document.createElement('div');
+    card.className = 'demo-card';
+    card.innerHTML = `
+      <h3>${demo.name}</h3>
+      <p class="small"><strong>Entry:</strong> ${demo.entry}</p>
+      <p class="small"><strong>Flow:</strong> ${demo.flow}</p>
+      <p>${demo.outputs}</p>
+    `;
+
+    const actions = document.createElement('div');
+    actions.className = 'demo-actions';
+
+    const openMission = document.createElement('a');
+    openMission.className = 'btn ghost';
+    openMission.textContent = 'Open Mission Architect';
+    openMission.href = demo.links.mission;
+    openMission.target = '_blank';
+    openMission.rel = 'noopener';
+    actions.appendChild(openMission);
+
+    const openTools = document.createElement('a');
+    openTools.className = 'btn subtle';
+    openTools.textContent = 'Open relevant tools';
+    openTools.href = '#';
+    openTools.addEventListener('click', (e) => {
+      e.preventDefault();
+      demo.links.tools.forEach(url => window.open(url, '_blank', 'noopener'));
+    });
+
+    actions.appendChild(openTools);
+    card.appendChild(actions);
+    grid.appendChild(card);
+  });
+}
+
+function initThemeToggle() {
+  const toggle = document.getElementById('themeToggle');
+  const saved = localStorage.getItem('ceradon-theme');
+  if (saved) {
+    document.documentElement.setAttribute('data-theme', saved);
+  }
+  toggle.textContent = document.documentElement.getAttribute('data-theme') === 'light' ? '☀️' : '🌙';
+
+  toggle.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'light' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('ceradon-theme', next);
+    toggle.textContent = next === 'light' ? '☀️' : '🌙';
+  });
+}
+
+function initApp() {
+  buildTools();
+  buildWorkflows();
+  buildDemos();
+  initThemeToggle();
+  handleHashChange();
+  window.addEventListener('hashchange', handleHashChange);
+}
+
+document.addEventListener('DOMContentLoaded', initApp);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ceradon Architect Stack</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="top-nav">
+    <div class="brand">
+      <div class="logo-dot" aria-hidden="true"></div>
+      <span class="wordmark">Ceradon Architect</span>
+    </div>
+    <nav aria-label="Primary">
+      <ul class="nav-links">
+        <li><a href="/#/home" data-route="home">Home</a></li>
+        <li><a href="/#/workflow" data-route="workflow">Workflow</a></li>
+        <li><a href="/#/tools" data-route="tools">Tools</a></li>
+        <li><a href="/#/mission" data-route="mission">Mission Architect</a></li>
+        <li><a href="/#/demos" data-route="demos">Demos</a></li>
+        <li><a href="/#/docs" data-route="docs">Docs</a></li>
+      </ul>
+    </nav>
+    <button class="toggle" id="themeToggle" aria-label="Toggle light or dark theme">🌙</button>
+  </header>
+
+  <main id="app" class="view-container">
+    <section id="home" class="view" aria-label="Home view">
+      <div class="hero">
+        <div>
+          <p class="eyebrow">Ceradon Systems | Architect Stack</p>
+          <h1>Ceradon Architect Stack – Planning, Design, and Mission Tools for Small UxS and RF Nodes</h1>
+          <p class="lead">Architect is the lab-level planning layer that bridges COTS UxS, RF relays, and sustainment kits with mission realities. Build missions, select platforms, shape meshes, and package kits without leaving the stack.</p>
+          <div class="hero-actions">
+            <a class="btn primary" href="/#/workflow">Explore Workflow</a>
+            <a class="btn ghost" href="/#/tools">Launch Tools</a>
+          </div>
+        </div>
+        <div class="hero-panel">
+          <h3>Stack At-a-Glance</h3>
+          <ul class="stack-list">
+            <li><strong>Mission Architect</strong><span>Mission-first composition and constraints.</span></li>
+            <li><strong>Node Architect</strong><span>Field nodes, payloads, and power envelopes.</span></li>
+            <li><strong>UxS Architect</strong><span>Platform pairing and loadouts.</span></li>
+            <li><strong>Mesh Architect</strong><span>RF coverage, relays, and gateways.</span></li>
+            <li><strong>KitSmith</strong><span>Kits, sustainment, and team packaging.</span></li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="card-grid" aria-label="Tool quick launch">
+        <article class="card">
+          <div>
+            <h3>Node Architect</h3>
+            <p>Define sensing nodes, payload stacks, and deployment envelopes from inventory or greenfield concepts.</p>
+          </div>
+          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html" target="_blank" rel="noopener">Launch</a>
+        </article>
+        <article class="card">
+          <div>
+            <h3>UxS Architect</h3>
+            <p>Pair nodes to unmanned air/ground/surface platforms with power, payload, and range checks.</p>
+          </div>
+          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-UxS-Architect/web/" target="_blank" rel="noopener">Launch</a>
+        </article>
+        <article class="card">
+          <div>
+            <h3>Mesh Architect</h3>
+            <p>Plan RF meshes, relays, and gateways to backhaul small teams and unmanned assets.</p>
+          </div>
+          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Mesh-Architect/" target="_blank" rel="noopener">Launch</a>
+        </article>
+        <article class="card">
+          <div>
+            <h3>KitSmith</h3>
+            <p>Assemble sustainment kits, spares, and team loadouts tied to mission phases.</p>
+          </div>
+          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-KitSmith/" target="_blank" rel="noopener">Launch</a>
+        </article>
+        <article class="card">
+          <div>
+            <h3>Mission Architect</h3>
+            <p>Compose missions, phases, and constraints that drive the rest of the stack.</p>
+          </div>
+          <a class="btn subtle" href="https://nbschultz97.github.io/Mission-Architect/" target="_blank" rel="noopener">Launch</a>
+        </article>
+      </div>
+    </section>
+
+    <section id="workflow" class="view" aria-label="Workflow view" hidden>
+      <div class="section-header">
+        <div>
+          <p class="eyebrow">Integrated planning loop</p>
+          <h2>Pick any entry point. Stay inside the loop.</h2>
+          <p class="lead">Mission-first, inventory-first, constraint-first, or RF-environment-first. Architect Stack keeps tools connected so phases, kits, meshes, and platforms stay in sync.</p>
+        </div>
+        <div class="loop-diagram" aria-hidden="true">
+          <div class="loop-node">Mission<br>Architect</div>
+          <div class="loop-node">Node<br>Architect</div>
+          <div class="loop-node">UxS<br>Architect</div>
+          <div class="loop-node">Mesh<br>Architect</div>
+          <div class="loop-node">KitSmith</div>
+          <svg class="loop-lines" viewBox="0 0 400 400" preserveAspectRatio="xMidYMid slice">
+            <circle cx="200" cy="200" r="140" />
+          </svg>
+        </div>
+      </div>
+      <div class="workflow-grid" id="workflowModes" aria-live="polite"></div>
+    </section>
+
+    <section id="tools" class="view" aria-label="Tools view" hidden>
+      <div class="section-header">
+        <p class="eyebrow">Tool hub</p>
+        <h2>All Architect modules, one launchpad</h2>
+        <p class="lead">Open live demos, check roles, and jump to the right planner without retracing steps.</p>
+      </div>
+      <div class="tool-grid" id="toolGrid" aria-live="polite"></div>
+    </section>
+
+    <section id="mission" class="view" aria-label="Mission Architect view" hidden>
+      <div class="section-header">
+        <p class="eyebrow">Mission-first entry</p>
+        <h2>Mission Architect – drive the stack from the mission down</h2>
+        <p class="lead">Compose phases, AO constraints, timelines, and outputs that downstream tools consume. This hub links directly to the existing Mission Architect app.</p>
+        <div class="mission-actions">
+          <a class="btn primary" href="https://nbschultz97.github.io/Mission-Architect/" target="_blank" rel="noopener">Open Mission Architect</a>
+          <a class="btn ghost" href="/#/workflow">See integrated workflow</a>
+        </div>
+      </div>
+      <div class="mission-layout">
+        <div class="card">
+          <h3>How Mission Architect fits</h3>
+          <ul class="bullet-list">
+            <li><strong>Outputs → Node Architect:</strong> Convert mission phases into node packages per leg.</li>
+            <li><strong>Outputs → UxS Architect:</strong> Match nodes to UxS platforms with loadouts tied to phases.</li>
+            <li><strong>Outputs → Mesh Architect:</strong> Use AO, altitudes, and RF constraints to shape relays and backhaul.</li>
+            <li><strong>Outputs → KitSmith:</strong> Turn teams, timelines, and resupply plans into kits and sustainment loads.</li>
+          </ul>
+          <div class="sample-flow">
+            <h4>Sample mission flow</h4>
+            <p>Start with recon-in-force across two phases. Build the mission in Mission Architect, export the spec, then:</p>
+            <ol>
+              <li>Push node requirements to Node Architect for sensor stack and power checks.</li>
+              <li>Send approved nodes to UxS Architect for platform pairing and sortie planning.</li>
+              <li>Feed AO geometry into Mesh Architect for RF coverage and relay placement.</li>
+              <li>Package sustainment in KitSmith aligned to each phase and team role.</li>
+            </ol>
+            <div class="quick-links">
+              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html" target="_blank" rel="noopener">Open Node Architect</a>
+              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-UxS-Architect/web/" target="_blank" rel="noopener">Open UxS Architect</a>
+              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Mesh-Architect/" target="_blank" rel="noopener">Open Mesh Architect</a>
+              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-KitSmith/" target="_blank" rel="noopener">Open KitSmith</a>
+            </div>
+          </div>
+        </div>
+        <div class="embed-card">
+          <h3>Live preview</h3>
+          <p class="small">Embedded view loads the existing Mission Architect app. If it does not load, use the primary button above.</p>
+          <div class="embed-container">
+            <iframe title="Mission Architect" src="https://nbschultz97.github.io/Mission-Architect/" loading="lazy"></iframe>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="demos" class="view" aria-label="Demos view" hidden>
+      <div class="section-header">
+        <p class="eyebrow">Integrated demo stories</p>
+        <h2>See the stack in action</h2>
+        <p class="lead">Pre-baked walkthroughs show how missions, nodes, meshes, and kits move together.</p>
+      </div>
+      <div class="demo-grid" id="demoGrid" aria-live="polite"></div>
+    </section>
+
+    <section id="docs" class="view" aria-label="Docs view" hidden>
+      <div class="section-header">
+        <p class="eyebrow">Docs & About</p>
+        <h2>What is Ceradon Architect Stack?</h2>
+        <p class="lead">Architect is the planning layer between COTS UxS/robotics and the logistics/C2 stack. It keeps mission intent, RF realities, and sustainment in lockstep.</p>
+      </div>
+      <div class="docs-layout">
+        <div class="card">
+          <h3>Modules</h3>
+          <ul class="bullet-list">
+            <li><strong>Mission Architect:</strong> Mission composition, constraints, AO geometry.</li>
+            <li><strong>Node Architect:</strong> Sensor nodes, payload stacking, power budgets.</li>
+            <li><strong>UxS Architect:</strong> Platform selection, loadouts, and sortie timing.</li>
+            <li><strong>Mesh Architect:</strong> RF backhaul, relays, gateways, spectrum assumptions.</li>
+            <li><strong>KitSmith:</strong> Sustainment kits, spares, and team packaging.</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>How it fits Ceradon</h3>
+          <p>Architect Stack pairs with Ceradon products such as Vantage, Phantom-Scout, ATAK plugins, Telemetry Forge, and Tactical-App to close the loop between sensing, control, and sustainment.</p>
+          <p>For more, visit <a href="https://ceradonsystems.com" target="_blank" rel="noopener">CeradonSystems.com</a>.</p>
+          <p class="small">This site is static and GitHub Pages–ready. Edit theme tokens in <code>assets/css/styles.css</code>, update routes in <code>assets/js/app.js</code>, and add tools or demos via the data structures near the top of <code>app.js</code>.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-links">
+      <a href="https://ceradonsystems.com" target="_blank" rel="noopener">CeradonSystems.com</a>
+      <a href="https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html" target="_blank" rel="noopener">Node Architect</a>
+      <a href="https://nbschultz97.github.io/Ceradon-UxS-Architect/web/" target="_blank" rel="noopener">UxS Architect</a>
+      <a href="https://nbschultz97.github.io/Ceradon-Mesh-Architect/" target="_blank" rel="noopener">Mesh Architect</a>
+      <a href="https://nbschultz97.github.io/Ceradon-KitSmith/" target="_blank" rel="noopener">KitSmith</a>
+      <a href="https://nbschultz97.github.io/Mission-Architect/" target="_blank" rel="noopener">Mission Architect</a>
+    </div>
+    <p class="small">Ceradon Systems LLC – Covert sensing, RF, and UxS planning tools.</p>
+  </footer>
+
+  <script src="assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a hash-based single-page layout with navigation, hero, workflow loop, tool hub, demos, docs, and Mission Architect integration via links/embed
- add dark-themed styling with responsive grids, cards, and a light/dark toggle to match Ceradon branding
- drive cards, workflows, and demos from data structures in app.js for easy maintenance and highlighting flows

## Testing
- Not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366c4de9cc8328afeedb70920b06ba)