### PR TITLE
Add access code gate for Ceradon Architect Stack demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,27 +8,130 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --gate-bg: #0f1117;
+      --gate-card: #161924;
+      --gate-border: rgba(255, 255, 255, 0.08);
+      --gate-text: #e8ecf3;
+      --gate-subtle: #a7afc3;
+      --gate-accent: #4da3ff;
+    }
+
+    #access-gate {
+      display: none;
+      min-height: 100vh;
+      background: var(--gate-bg);
+      color: var(--gate-text);
+      font-family: system-ui, -apple-system, "Inter", sans-serif;
+      padding: 48px 16px;
+      box-sizing: border-box;
+    }
+
+    .gate-shell {
+      max-width: 560px;
+      margin: 0 auto;
+      background: var(--gate-card);
+      border: 1px solid var(--gate-border);
+      border-radius: 16px;
+      padding: 32px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+    }
+
+    .gate-shell h1 {
+      margin: 0 0 12px;
+      font-size: clamp(24px, 4vw, 30px);
+      line-height: 1.25;
+    }
+
+    .gate-shell p {
+      margin: 0 0 20px;
+      color: var(--gate-subtle);
+      line-height: 1.5;
+    }
+
+    .gate-form {
+      display: grid;
+      gap: 12px;
+    }
+
+    .gate-form label {
+      font-weight: 600;
+      color: var(--gate-text);
+    }
+
+    .gate-form input {
+      padding: 12px;
+      border-radius: 10px;
+      border: 1px solid var(--gate-border);
+      background: #0c0e15;
+      color: var(--gate-text);
+      font-size: 16px;
+    }
+
+    .gate-form button {
+      padding: 12px 16px;
+      border: none;
+      border-radius: 10px;
+      background: var(--gate-accent);
+      color: #0b0e17;
+      font-weight: 700;
+      font-size: 16px;
+      cursor: pointer;
+      transition: transform 120ms ease, box-shadow 120ms ease;
+    }
+
+    .gate-form button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 8px 24px rgba(77, 163, 255, 0.25);
+    }
+
+    .gate-form button:active {
+      transform: translateY(0);
+      box-shadow: none;
+    }
+
+    .error-message {
+      color: #f77b7b;
+      font-size: 14px;
+      display: none;
+    }
+  </style>
 </head>
 <body>
-  <header class="top-nav">
-    <div class="brand">
-      <div class="logo-dot" aria-hidden="true"></div>
-      <span class="wordmark">Ceradon Architect</span>
+  <div id="access-gate">
+    <div class="gate-shell" role="dialog" aria-labelledby="gateTitle" aria-describedby="gateDescription">
+      <h1 id="gateTitle">Ceradon Systems — Ceradon Architect Stack Demo</h1>
+      <p id="gateDescription">Enter your demo access code to view the Architect Stack hub and launch tools.</p>
+      <div class="gate-form">
+        <label for="demo-code">Access code</label>
+        <input id="demo-code" type="password" autocomplete="off" inputmode="numeric" aria-describedby="demo-error">
+        <button id="demo-enter" type="button">Enter</button>
+        <div id="demo-error" class="error-message" role="alert">Invalid code.</div>
+      </div>
     </div>
-    <nav aria-label="Primary">
-      <ul class="nav-links">
-        <li><a href="/#/home" data-route="home">Home</a></li>
-        <li><a href="/#/workflow" data-route="workflow">Workflow</a></li>
-        <li><a href="/#/tools" data-route="tools">Tools</a></li>
-        <li><a href="/#/mission" data-route="mission">Mission Architect</a></li>
-        <li><a href="/#/demos" data-route="demos">Demos</a></li>
-        <li><a href="/#/docs" data-route="docs">Docs</a></li>
-      </ul>
-    </nav>
-    <button class="toggle" id="themeToggle" aria-label="Toggle light or dark theme">🌙</button>
-  </header>
+  </div>
 
-  <main id="app" class="view-container">
+  <div id="app-root" style="display: none;">
+    <header class="top-nav">
+      <div class="brand">
+        <div class="logo-dot" aria-hidden="true"></div>
+        <span class="wordmark">Ceradon Architect</span>
+      </div>
+      <nav aria-label="Primary">
+        <ul class="nav-links">
+          <li><a href="/#/home" data-route="home">Home</a></li>
+          <li><a href="/#/workflow" data-route="workflow">Workflow</a></li>
+          <li><a href="/#/tools" data-route="tools">Tools</a></li>
+          <li><a href="/#/mission" data-route="mission">Mission Architect</a></li>
+          <li><a href="/#/demos" data-route="demos">Demos</a></li>
+          <li><a href="/#/docs" data-route="docs">Docs</a></li>
+        </ul>
+      </nav>
+      <button class="toggle" id="themeToggle" aria-label="Toggle light or dark theme">🌙</button>
+    </header>
+
+    <main id="app" class="view-container">
     <section id="home" class="view" aria-label="Home view">
       <div class="hero">
         <div>
@@ -214,7 +317,58 @@
     </div>
     <p class="small">Ceradon Systems LLC – Covert sensing, RF, and UxS planning tools.</p>
   </footer>
+  </div>
 
   <script src="assets/js/app.js"></script>
+  <script>
+    (() => {
+      const ACCESS_CODE = "ARC-STACK-761";
+      const STORAGE_KEY = "ceradonDemoAuthorized";
+      const gate = document.getElementById("access-gate");
+      const appRoot = document.getElementById("app-root");
+      const input = document.getElementById("demo-code");
+      const submit = document.getElementById("demo-enter");
+      const error = document.getElementById("demo-error");
+
+      function showApp() {
+        if (gate) gate.style.display = "none";
+        if (appRoot) appRoot.style.display = "block";
+      }
+
+      function showGate() {
+        if (gate) gate.style.display = "block";
+        if (appRoot) appRoot.style.display = "none";
+      }
+
+      function handleAuth() {
+        const value = (input?.value || "").trim();
+        if (value === ACCESS_CODE) {
+          localStorage.setItem(STORAGE_KEY, "true");
+          if (error) error.style.display = "none";
+          showApp();
+        } else {
+          if (error) error.style.display = "block";
+        }
+      }
+
+      document.addEventListener("DOMContentLoaded", () => {
+        const authorized = localStorage.getItem(STORAGE_KEY) === "true";
+        if (authorized) {
+          showApp();
+          return;
+        }
+
+        showGate();
+
+        submit?.addEventListener("click", handleAuth);
+        input?.addEventListener("keydown", (event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            handleAuth();
+          }
+        });
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap existing hub content in a hidden app container
- add an access gate UI with styling and localStorage-based unlock
- ensure the hub auto-unlocks on subsequent visits after a successful code entry

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936770b44ec832883ce0fa28b21fdf3)