### PR TITLE
Add demo code request section

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -183,6 +183,55 @@ h1, h2, h3, h4 {
   flex-wrap: wrap;
 }
 
+.demo-request {
+  margin: 26px 0 32px;
+  padding: 28px 18px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+}
+
+.demo-request-inner {
+  max-width: 1040px;
+  margin: 0 auto;
+  display: grid;
+  gap: 12px;
+}
+
+.demo-request-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.demo-request-btn {
+  min-width: 220px;
+  text-align: center;
+}
+
+.demo-request-email {
+  margin: 0;
+  color: var(--muted);
+}
+
+.demo-request-email a {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+@media (min-width: 640px) {
+  .demo-request-actions {
+    flex-direction: row;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .demo-request-email {
+    margin: 0;
+  }
+}
+
 .btn {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -192,6 +192,30 @@
           <a class="btn subtle" href="https://nbschultz97.github.io/Mission-Architect/" target="_blank" rel="noopener">Launch</a>
         </article>
       </div>
+
+      <section id="demo-request" class="demo-request">
+        <div class="demo-request-inner">
+          <h2>Request a demo code</h2>
+          <p>
+            Ceradon Systems provides controlled access to <strong>Ceradon Mission Architect</strong> for qualified organizations.
+            Request a demo code to explore the live planner and see how it fits your mission profiles.
+          </p>
+          <div class="demo-request-actions">
+            <a
+              id="demo-request-button"
+              class="btn primary demo-request-btn"
+              href="mailto:contact@ceradonsystems.com?subject=Demo%20code%20request%20%E2%80%93%20Ceradon%20Mission%20Architect&body=Hi%20Ceradon%20team,%0D%0A%0D%0AI%27d%20like%20to%20request%20a%20demo%20access%20code%20for%20Ceradon%20Mission%20Architect.%0D%0A%0D%0AOrganization:%20%0D%0AUse%20case:%20%0D%0ATimeline:%20%0D%0A%0D%0AThank%20you.">
+              Request a demo code
+            </a>
+
+            <p class="demo-request-email">
+              Or email us at
+              <a href="mailto:contact@ceradonsystems.com?subject=Demo%20code%20request%20%E2%80%93%20Ceradon%20Mission%20Architect">contact@ceradonsystems.com</a>
+              with your organization and use case.
+            </p>
+          </div>
+        </div>
+      </section>
     </section>
 
     <section id="workflow" class="view" aria-label="Workflow view" hidden>


### PR DESCRIPTION
## Summary
- add a demo code request section that explains access requirements for Ceradon Mission Architect
- provide mailto-based CTA and direct email link to request demo access
- style the new block to align with the existing landing page layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367c722a3c8328a4235f6124872118)