### PR TITLE
Add mission workflow dashboard and shared project schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,74 @@
 # Ceradon Architect Stack Hub
 
-This repo is the front-door, static SPA hub for the Ceradon Architect tools, published via GitHub Pages at <https://nbschultz97.github.io/Ceradon-Architect/>. It links to the live module apps and explains the integrated planning workflow.
+This repo is the front-door, static SPA hub for the Ceradon Architect tools, published via GitHub Pages at <https://nbschultz97.github.io/Ceradon-Architect/>. It links to the live module apps, explains the integrated planning workflow, and now provides a single-page Mission Workflow dashboard that embeds every planner.
 
 ## Quick start
 - Serve locally with any static file host (e.g., `python -m http.server 8000`) and open `http://localhost:8000`.
 - Navigate with hash routes: `/#/home`, `/#/workflow`, `/#/tools`, `/#/mission`, `/#/demos`, `/#/docs`.
 - Use the light/dark toggle in the nav to switch themes.
+- Open `/#/workflow` to reach the unified Mission Workflow dashboard with embedded tools, module status selectors, project import/export controls, and feasibility checks.
 
 ## Updating content
 - **Theme tokens:** edit `assets/css/styles.css` (`:root` and `[data-theme="light"]`).
 - **Routes & views:** sections live in `index.html`; routing is in `assets/js/app.js`.
 - **Tools:** update the `toolData` array in `assets/js/app.js` to add or change tool cards.
-- **Workflow modes:** adjust the `workflowModes` array in `assets/js/app.js`.
+- **Workflow dashboard:** adjust the `workflowModules` array in `assets/js/app.js` to point the left-nav items to new URLs or change descriptions. The dashboard uses iframes by default to keep everything static-hostable.
 - **Demo stories:** edit the `demoStories` array in `assets/js/app.js`.
 - **Mission Architect embed:** update the iframe/link URL in the `mission` section of `index.html`.
+
+## Mission Workflow dashboard
+- Navigate to `/#/workflow` to stay in one shell while operating the core modules:
+  - Platform Designer (Node + UxS Architect)
+  - Mesh Planner (Mesh Architect)
+  - Mission Planner (Mission Architect)
+  - KitSmith
+- Each module opens in an iframe with quick-launch links. A per-module status selector (Not Started / In Progress / Complete) is stored in `localStorage` under `ceradon_module_statuses`.
+- A mission project panel exposes shared metadata fields and import/export buttons to keep a single JSON object in sync across tools.
+- A feasibility panel reads the stored project JSON and highlights sustainment coverage, kit weight margins, and comms relay redundancy.
+
+## MissionProject schema and helpers
+- A shared schema lives in `assets/js/project.js` and persists to `localStorage` under `ceradon_mission_project`. Tools can copy this helper module to stay consistent.
+- Core shape:
+
+```json
+{
+  "missionMeta": {
+    "name": "Untitled mission",
+    "environment": {
+      "altitudeBand": "0-1000m",
+      "temperatureBand": "10-25C"
+    },
+    "durationHours": 24
+  },
+  "inventoryCatalog": {
+    "reference": "Pending catalog reference",
+    "parts": []
+  },
+  "nodeDesigns": [],
+  "uxsDesigns": [],
+  "meshPlan": {
+    "nodes": [],
+    "links": [],
+    "relayCount": 0,
+    "criticalLinks": 0,
+    "losSummary": []
+  },
+  "kitPlans": {
+    "kits": [],
+    "perPersonLoadWeight": 18,
+    "weightLimit": 22,
+    "sustainmentHours": 24,
+    "batteryCounts": 0
+  }
+}
+```
+
+- Helper API exposed globally as `MissionProjectStore`:
+  - `loadMissionProject()` / `saveMissionProject(updatedProject)`
+  - `updateMissionMeta(partialMeta)`
+  - `exportMissionProject(fileName)` / `importMissionProject(file)`
+  - `defaultProject` and `STORAGE_KEY` for reference
+- The workflow dashboard form writes directly to this object, so other repos can read the same structure without extra wiring.
 
 ## Tool deep links
 - Node Architect: <https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -327,6 +327,171 @@ h1, h2, h3, h4 {
 .status.prototype { color: #fbbf24; border-color: #fbbf2433; }
 .status.planned { color: #f87171; border-color: #f8717133; }
 
+.workflow-dashboard {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+@media (max-width: 960px) {
+  .workflow-dashboard {
+    grid-template-columns: 1fr;
+  }
+}
+
+.module-sidebar {
+  display: grid;
+  gap: 10px;
+}
+
+.module-nav-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  padding: 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.module-nav-item:hover,
+.module-nav-item:focus-visible {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.module-nav-item.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(77, 163, 255, 0.2);
+}
+
+.module-nav-text {
+  display: grid;
+  gap: 4px;
+}
+
+.status-pill {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+}
+
+.status-pill.not-started { color: var(--muted); }
+.status-pill.in-progress { color: #fbbf24; border-color: #fbbf2433; }
+.status-pill.complete { color: #2dd4bf; border-color: #2dd4bf33; }
+
+.module-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+}
+
+.module-panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.status-control {
+  display: grid;
+  gap: 6px;
+}
+
+.status-control select {
+  padding: 8px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+}
+
+.module-links {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 10px 0;
+}
+
+.module-panel .embed-container {
+  padding-top: 65%;
+  min-height: 320px;
+  border-radius: 12px;
+}
+
+.project-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.project-card,
+.feasibility-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 16px;
+  box-shadow: var(--shadow);
+}
+
+.project-form .form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.project-form input,
+.project-form select {
+  width: 100%;
+  padding: 10px;
+  margin-top: 6px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+}
+
+.project-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.feasibility-header {
+  display: grid;
+  gap: 6px;
+}
+
+.feasibility-items {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.feasibility-item {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--card);
+  border-left: 4px solid var(--border);
+}
+
+.feasibility-item.good { border-left-color: #2dd4bf; }
+.feasibility-item.warning { border-left-color: #fbbf24; }
+.feasibility-item.alert { border-left-color: #f87171; }
+
 .workflow-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/assets/js/project.js
+++ b/assets/js/project.js
@@ -1,0 +1,110 @@
+// Shared mission project helpers for Ceradon Architect Stack
+// Exposes a stable MissionProject schema and localStorage persistence so sibling tools can adopt the same contract.
+
+const MissionProjectStore = (() => {
+  const STORAGE_KEY = 'ceradon_mission_project';
+
+  const defaultProject = {
+    missionMeta: {
+      name: 'Untitled mission',
+      environment: {
+        altitudeBand: '0-1000m',
+        temperatureBand: '10-25C'
+      },
+      durationHours: 24
+    },
+    inventoryCatalog: {
+      reference: 'Pending catalog reference',
+      parts: []
+    },
+    nodeDesigns: [],
+    uxsDesigns: [],
+    meshPlan: {
+      nodes: [],
+      links: [],
+      relayCount: 0,
+      criticalLinks: 0,
+      losSummary: []
+    },
+    kitPlans: {
+      kits: [],
+      perPersonLoadWeight: 18,
+      weightLimit: 22,
+      sustainmentHours: 24,
+      batteryCounts: 0
+    }
+  };
+
+  const cloneDefault = () => JSON.parse(JSON.stringify(defaultProject));
+
+  const loadMissionProject = () => {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return cloneDefault();
+    try {
+      const parsed = JSON.parse(raw);
+      return { ...cloneDefault(), ...parsed, missionMeta: { ...cloneDefault().missionMeta, ...parsed.missionMeta, environment: { ...cloneDefault().missionMeta.environment, ...(parsed.missionMeta?.environment || {}) } }, inventoryCatalog: { ...cloneDefault().inventoryCatalog, ...parsed.inventoryCatalog }, meshPlan: { ...cloneDefault().meshPlan, ...parsed.meshPlan }, kitPlans: { ...cloneDefault().kitPlans, ...parsed.kitPlans } };
+    } catch (error) {
+      console.warn('Failed to parse mission project, resetting to default', error);
+      return cloneDefault();
+    }
+  };
+
+  const saveMissionProject = (updatedProject) => {
+    const toPersist = { ...cloneDefault(), ...updatedProject };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(toPersist));
+    return toPersist;
+  };
+
+  const updateMissionMeta = (partialMeta) => {
+    const project = loadMissionProject();
+    const merged = {
+      ...project,
+      missionMeta: {
+        ...project.missionMeta,
+        ...partialMeta,
+        environment: {
+          ...project.missionMeta.environment,
+          ...(partialMeta.environment || {})
+        }
+      }
+    };
+    return saveMissionProject(merged);
+  };
+
+  const exportMissionProject = (fileName = 'ceradon_mission_project.json') => {
+    const project = loadMissionProject();
+    const blob = new Blob([JSON.stringify(project, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importMissionProject = (file) => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const parsed = JSON.parse(event.target.result || '{}');
+        const saved = saveMissionProject(parsed);
+        resolve(saved);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(file);
+  });
+
+  return {
+    defaultProject,
+    cloneDefault,
+    loadMissionProject,
+    saveMissionProject,
+    updateMissionMeta,
+    exportMissionProject,
+    importMissionProject,
+    STORAGE_KEY
+  };
+})();

--- a/index.html
+++ b/index.html
@@ -252,22 +252,106 @@
     <section id="workflow" class="view" aria-label="Workflow view" hidden>
       <div class="section-header">
         <div>
-          <p class="eyebrow">Integrated planning loop</p>
-          <h2>Pick any entry point. Stay inside the loop.</h2>
-          <p class="lead">Mission-first, inventory-first, constraint-first, or RF-environment-first. Architect Stack keeps tools connected so phases, kits, meshes, and platforms stay in sync.</p>
-        </div>
-        <div class="loop-diagram" aria-hidden="true">
-          <div class="loop-node">Mission<br>Architect</div>
-          <div class="loop-node">Node<br>Architect</div>
-          <div class="loop-node">UxS<br>Architect</div>
-          <div class="loop-node">Mesh<br>Architect</div>
-          <div class="loop-node">KitSmith</div>
-          <svg class="loop-lines" viewBox="0 0 400 400" preserveAspectRatio="xMidYMid slice">
-            <circle cx="200" cy="200" r="140" />
-          </svg>
+          <p class="eyebrow">Mission Workflow</p>
+          <h2>One dashboard, four modules. Move missions without leaving the shell.</h2>
+          <p class="lead">Stay on a single page to embed platform, mesh, mission, and kit planners. Update module status, keep a shared mission project JSON in localStorage, and export/import as you go.</p>
         </div>
       </div>
-      <div class="workflow-grid" id="workflowModes" aria-live="polite"></div>
+
+      <div class="workflow-dashboard">
+        <aside class="module-sidebar" id="moduleSidebar" aria-label="Workflow module navigation"></aside>
+
+        <div class="workflow-main">
+          <div class="module-panel">
+            <div class="module-panel-header">
+              <div>
+                <p class="eyebrow" id="moduleCategory">Module</p>
+                <h3 id="moduleTitle">Platform Designer (Node + UxS)</h3>
+                <p class="small" id="moduleDescription"></p>
+              </div>
+              <div class="status-control">
+                <label for="moduleStatus">Status</label>
+                <select id="moduleStatus" aria-label="Module status selector">
+                  <option value="Not Started">Not Started</option>
+                  <option value="In Progress">In Progress</option>
+                  <option value="Complete">Complete</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="module-links" id="moduleLinks"></div>
+            <div class="embed-container" id="moduleEmbed"></div>
+          </div>
+
+          <div class="project-layout">
+            <div class="card project-card">
+              <h3>Mission project</h3>
+              <p class="small">Edit the shared mission project JSON that every module reads and writes. Values persist locally under <code>ceradon_mission_project</code>.</p>
+
+              <form class="project-form" id="projectMetaForm">
+                <div class="form-grid">
+                  <label>Mission name
+                    <input type="text" id="missionName" name="missionName" autocomplete="off">
+                  </label>
+                  <label>Environment – altitude band
+                    <select id="altitudeBand" name="altitudeBand">
+                      <option value="0-1000m">0-1000m</option>
+                      <option value="1000-2500m">1000-2500m</option>
+                      <option value=">2500m">&gt;2500m</option>
+                    </select>
+                  </label>
+                  <label>Environment – temperature band
+                    <select id="temperatureBand" name="temperatureBand">
+                      <option value="10-25C">10-25°C</option>
+                      <option value="-10-10C">-10 to 10°C</option>
+                      <option value="25-40C">25-40°C</option>
+                    </select>
+                  </label>
+                  <label>Duration (hours)
+                    <select id="durationHours" name="durationHours">
+                      <option value="24">24</option>
+                      <option value="48">48</option>
+                      <option value="72">72</option>
+                    </select>
+                  </label>
+                  <label>Inventory catalog reference
+                    <input type="text" id="inventoryReference" name="inventoryReference" autocomplete="off">
+                  </label>
+                  <label>Planned sustainment hours
+                    <input type="number" id="sustainmentHours" name="sustainmentHours" min="0" step="1">
+                  </label>
+                  <label>Per-person kit load (kg)
+                    <input type="number" id="perPersonLoad" name="perPersonLoad" min="0" step="0.5">
+                  </label>
+                  <label>Per-person weight limit (kg)
+                    <input type="number" id="perPersonLimit" name="perPersonLimit" min="0" step="0.5">
+                  </label>
+                  <label>Comms relay count
+                    <input type="number" id="relayCount" name="relayCount" min="0" step="1">
+                  </label>
+                  <label>Critical links
+                    <input type="number" id="criticalLinks" name="criticalLinks" min="0" step="1">
+                  </label>
+                </div>
+              </form>
+
+              <div class="project-actions">
+                <button class="btn primary" id="exportProject">Export Project (.json)</button>
+                <button class="btn ghost" id="importProject">Import Project (.json)</button>
+                <input type="file" id="importProjectFile" accept="application/json" hidden>
+              </div>
+            </div>
+
+            <div class="card feasibility-card">
+              <div class="feasibility-header">
+                <h3>Mission Feasibility</h3>
+                <p class="small">Reads from the stored project JSON. Color cues flag sustainment, weight, and comms coverage gaps.</p>
+              </div>
+              <div class="feasibility-items" id="feasibilityItems"></div>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
     <section id="tools" class="view" aria-label="Tools view" hidden>
@@ -374,6 +458,7 @@
   </footer>
   </div>
 
+  <script src="assets/js/project.js"></script>
   <script src="assets/js/app.js"></script>
   <script>
     (() => {


### PR DESCRIPTION
## Summary
- build a single-page Mission Workflow dashboard with embedded module iframes, local module status selectors, and project controls
- add a shared MissionProject schema/helper module plus import/export wiring and feasibility checks tied to stored JSON
- refresh styling and documentation to describe the new dashboard and data contract

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69374c6d04f88328a38e8343a2a8109c)