### PR TITLE
Refocus hub on WHITEFROST demo entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ This repo is the front-door, static SPA hub for the Ceradon Architect tools, pub
 - WHITEFROST demo: `data/whitefrost_demo_project.json` provides the cold-weather scenario with TAK-ready exports.
 
 ## Tool deep links
-- Node Architect: <https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html>
-- UxS Architect: <https://nbschultz97.github.io/Ceradon-UxS-Architect/web/>
-- Mesh Architect: <https://nbschultz97.github.io/Ceradon-Mesh-Architect/>
-- KitSmith: <https://nbschultz97.github.io/Ceradon-KitSmith/>
-- Mission Architect: <https://nbschultz97.github.io/Mission-Architect/>
+- Node Architect: <https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
+- UxS Architect: <https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
+- Mesh Architect: <https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
+- KitSmith: <https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761>
+- Mission Architect: <https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
 
 ## Notes
 - The site is fully static and GitHub Pages–compatible; no backend or build tooling is required.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -143,11 +143,130 @@ h1, h2, h3, h4 {
   max-width: 760px;
 }
 
-.hero {
+.hero { 
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 20px;
   margin-bottom: 24px;
+}
+
+.whitefrost-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+}
+
+.whitefrost-toggle .btn.active {
+  background: var(--accent);
+  color: #0b0e17;
+  border: 1px solid var(--accent);
+}
+
+.whitefrost-panel {
+  margin: 28px 0 12px;
+  padding: 18px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(77, 163, 255, 0.12), rgba(255, 255, 255, 0.02));
+  box-shadow: var(--shadow);
+}
+
+.whitefrost-panel .panel-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.whitefrost-panel .badge {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.toolchain {
+  margin: 32px 0;
+  padding: 18px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  box-shadow: var(--shadow);
+}
+
+.strip-title {
+  margin: 0 0 6px;
+}
+
+.toolchain-steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 14px;
+  margin: 16px 0;
+}
+
+.step-card {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 14px;
+  background: var(--card);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.entry-modes {
+  border-top: 1px solid var(--border);
+  margin-top: 16px;
+  padding-top: 12px;
+}
+
+.entry-diagram {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.entry-node {
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  background: var(--card);
+  font-weight: 700;
+}
+
+.entry-sub {
+  display: block;
+  font-weight: 400;
+  color: var(--muted);
+  margin-top: 6px;
+}
+
+.missionproject-callout {
+  margin: 20px 0 8px;
+  padding: 18px;
+  border-radius: 16px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.code-snippet {
+  background: #0c121c;
+  border: 1px solid var(--border);
+  padding: 12px;
+  border-radius: 12px;
+  overflow: auto;
 }
 
 .hero-panel {
@@ -197,6 +316,10 @@ h1, h2, h3, h4 {
   margin: 0 auto;
   display: grid;
   gap: 12px;
+}
+
+.demo-note {
+  margin-top: 6px;
 }
 
 .demo-request-actions {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10,7 +10,7 @@ const toolData = [
     description: 'Mission-first entry point for phases, AO geometry, and constraints that drive the rest of the stack.',
     status: 'Live demo',
     badges: ['Mission composition', 'JSON export'],
-    link: 'https://nbschultz97.github.io/Mission-Architect/'
+    link: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
   },
   {
     name: 'Node Architect',
@@ -18,7 +18,7 @@ const toolData = [
     description: 'Define sensing nodes, payload stacks, power envelopes, and deployment conditions.',
     status: 'Live demo',
     badges: ['Node planning', 'Payload design'],
-    link: 'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html'
+    link: 'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
   },
   {
     name: 'UxS Architect',
@@ -26,7 +26,7 @@ const toolData = [
     description: 'Pair nodes to UxS platforms (air/ground/surface) with loadouts and sortie timing.',
     status: 'Live demo',
     badges: ['Platform design', 'Loadouts'],
-    link: 'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/'
+    link: 'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
   },
   {
     name: 'Mesh Architect',
@@ -34,7 +34,7 @@ const toolData = [
     description: 'Shape RF meshes, relays, and gateways for contested environments.',
     status: 'Live demo',
     badges: ['Mesh / RF', 'Coverage'],
-    link: 'https://nbschultz97.github.io/Ceradon-Mesh-Architect/'
+    link: 'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
   },
   {
     name: 'KitSmith',
@@ -42,7 +42,7 @@ const toolData = [
     description: 'Build kits, spares, and sustainment loads aligned to mission phases and roles.',
     status: 'Live demo',
     badges: ['Kits & sustainment', 'Resupply'],
-    link: 'https://nbschultz97.github.io/Ceradon-KitSmith/'
+    link: 'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761'
   }
 ];
 
@@ -52,10 +52,10 @@ const workflowModules = [
     name: 'Platform Designer (Node + UxS)',
     category: 'Platform Designer',
     description: 'Shape sensing nodes and pair them with UxS lift. Keep payload, power, and sortie timing together.',
-    iframe: 'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html',
+    iframe: 'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
     links: [
-      { label: 'Open Node Architect', href: 'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html' },
-      { label: 'Open UxS Architect', href: 'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/' }
+      { label: 'Open Node Architect', href: 'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761' },
+      { label: 'Open UxS Architect', href: 'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761' }
     ]
   },
   {
@@ -63,9 +63,9 @@ const workflowModules = [
     name: 'Mesh Planner',
     category: 'Mesh Planner',
     description: 'Plan relays, LOS/NLOS links, and coverage so critical links stay redundant.',
-    iframe: 'https://nbschultz97.github.io/Ceradon-Mesh-Architect/',
+    iframe: 'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
     links: [
-      { label: 'Open Mesh Architect', href: 'https://nbschultz97.github.io/Ceradon-Mesh-Architect/' }
+      { label: 'Open Mesh Architect', href: 'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761' }
     ]
   },
   {
@@ -73,10 +73,10 @@ const workflowModules = [
     name: 'Mission Planner',
     category: 'Mission Planner',
     description: 'Mission Architect drives phases, AO constraints, and exports that feed every downstream tool.',
-    iframe: 'https://nbschultz97.github.io/Mission-Architect/',
+    iframe: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
     links: [
-      { label: 'Open Mission Architect', href: 'https://nbschultz97.github.io/Mission-Architect/' },
-      { label: 'Mission Architect print view', href: 'https://nbschultz97.github.io/Mission-Architect/print.html' }
+      { label: 'Open Mission Architect', href: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761' },
+      { label: 'Mission Architect print view', href: 'https://mission-architect.ceradonsystems.com/print.html?access_code=ARC-STACK-761' }
     ]
   },
   {
@@ -84,10 +84,10 @@ const workflowModules = [
     name: 'KitSmith',
     category: 'KitSmith',
     description: 'Sustainment packaging, batteries, and per-person loads tied to mission phases.',
-    iframe: 'https://nbschultz97.github.io/Ceradon-KitSmith/',
+    iframe: 'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761',
     links: [
-      { label: 'Open KitSmith', href: 'https://nbschultz97.github.io/Ceradon-KitSmith/' },
-      { label: 'KitSmith print view', href: 'https://nbschultz97.github.io/Ceradon-KitSmith/print.html' }
+      { label: 'Open KitSmith', href: 'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761' },
+      { label: 'KitSmith print view', href: 'https://kitsmith.ceradonsystems.com/print.html?access_code=ARC-STACK-761' }
     ]
   }
 ];
@@ -99,12 +99,12 @@ const demoStories = [
     flow: 'Mission Architect → Node Architect → UxS Architect → Mesh Architect → KitSmith',
     outputs: 'Cold-weather printed quad, ridge relays, partner sustainment cache, and TAK-friendly exports.',
     links: {
-      mission: 'https://nbschultz97.github.io/Mission-Architect/',
+      mission: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
       tools: [
-        'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html',
-        'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/',
-        'https://nbschultz97.github.io/Ceradon-Mesh-Architect/',
-        'https://nbschultz97.github.io/Ceradon-KitSmith/'
+        'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+        'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+        'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+        'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761'
       ]
     }
   },
@@ -114,13 +114,13 @@ const demoStories = [
     flow: 'Mesh Architect → Mission Architect → Node Architect → UxS Architect → KitSmith',
     outputs: 'RF survey-driven relays, mission phases constrained to coverage pockets, small quad loadouts, lean kits.',
     links: {
-      mission: 'https://nbschultz97.github.io/Mission-Architect/',
+      mission: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
       tools: [
-        'https://nbschultz97.github.io/Ceradon-Mesh-Architect/',
-        'https://nbschultz97.github.io/Mission-Architect/',
-        'https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html',
-        'https://nbschultz97.github.io/Ceradon-UxS-Architect/web/',
-        'https://nbschultz97.github.io/Ceradon-KitSmith/'
+        'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+        'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+        'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+        'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+        'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761'
       ]
     }
   }
@@ -570,11 +570,33 @@ function initThemeToggle() {
   });
 }
 
+function initWhitefrostMode() {
+  const toggle = document.getElementById('whitefrostToggle');
+  const panel = document.getElementById('whitefrostPanel');
+  if (!toggle || !panel) return;
+
+  const stored = localStorage.getItem('ceradon-whitefrost-mode') === 'true';
+  if (stored) {
+    panel.hidden = false;
+    toggle.classList.add('active');
+    toggle.textContent = 'WHITEFROST Demo Mode On';
+  }
+
+  toggle.addEventListener('click', () => {
+    const nextState = panel.hidden;
+    panel.hidden = !panel.hidden;
+    toggle.classList.toggle('active', nextState);
+    toggle.textContent = nextState ? 'WHITEFROST Demo Mode On' : 'Enable WHITEFROST Demo Mode';
+    localStorage.setItem('ceradon-whitefrost-mode', nextState);
+  });
+}
+
 function initApp() {
   buildTools();
   buildDemos();
   initWorkflowDashboard();
   initThemeToggle();
+  initWhitefrostMode();
   handleHashChange();
   window.addEventListener('hashchange', handleHashChange);
 }

--- a/index.html
+++ b/index.html
@@ -167,11 +167,15 @@
       <div class="hero">
         <div>
           <p class="eyebrow">Ceradon Systems | Architect Stack</p>
-          <h1>Ceradon Architect Stack – Planning, Design, and Mission Tools for Small UxS and RF Nodes</h1>
-          <p class="lead">Architect is the lab-level planning layer that bridges COTS UxS, RF relays, and sustainment kits with mission realities. Build missions, select platforms, shape meshes, and package kits without leaving the stack.</p>
+          <h1>Ceradon Architect Stack – Project WHITEFROST Demo</h1>
+          <p class="lead">The Architect stack plans, designs, and sustains small unmanned systems for cold, mountainous, austere environments. Project WHITEFROST is a public, fictional demo: low-cost 3D-printed recon quad, ridge-top mesh relays, and partner forces operating in a remote highlands corridor.</p>
           <div class="hero-actions">
             <a class="btn primary" href="/#/workflow">Explore Workflow</a>
             <a class="btn ghost" href="/#/tools">Launch Tools</a>
+          </div>
+          <div class="whitefrost-toggle" role="group" aria-label="WHITEFROST demo mode">
+            <button class="btn subtle" id="whitefrostToggle" type="button">Enable WHITEFROST Demo Mode</button>
+            <span class="small muted">Public-safe, fictional scenario. No unit-specific data.</span>
           </div>
         </div>
         <div class="hero-panel">
@@ -186,42 +190,120 @@
         </div>
       </div>
 
+      <div class="toolchain" aria-label="Architect toolchain">
+        <h2 class="strip-title">Toolchain</h2>
+        <p class="lead">Move through the stack in sequence or jump in by mission, inventory, or RF need. Every step honors the same demo access code and WHITEFROST scenario.</p>
+        <div class="toolchain-steps">
+          <article class="step-card">
+            <div>
+              <p class="eyebrow">Step 1</p>
+              <h3>Node Architect</h3>
+              <p>Outline sensing nodes, payload stacks, and power envelopes for cold-weather hides and relay sites.</p>
+            </div>
+            <a class="btn primary" href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+          </article>
+          <article class="step-card">
+            <div>
+              <p class="eyebrow">Step 2</p>
+              <h3>UxS Architect</h3>
+              <p>Pair the nodes to low-cost airframes, check lift/power margins, and keep sorties aligned to terrain.</p>
+            </div>
+            <a class="btn primary" href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+          </article>
+          <article class="step-card">
+            <div>
+              <p class="eyebrow">Step 3</p>
+              <h3>Mesh Architect</h3>
+              <p>Plan ridge-line relays, mesh redundancy, and RF entry points that survive high-altitude cold soak.</p>
+            </div>
+            <a class="btn primary" href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+          </article>
+          <article class="step-card">
+            <div>
+              <p class="eyebrow">Step 4</p>
+              <h3>KitSmith</h3>
+              <p>Package ruck-level spares, batteries, and field repairs that match cold-weather sortie plans.</p>
+            </div>
+            <a class="btn primary" href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+          </article>
+          <article class="step-card">
+            <div>
+              <p class="eyebrow">Step 5</p>
+              <h3>Mission Architect</h3>
+              <p>Drive phases, constraints, and partner overlays for the WHITEFROST corridor without exposing real units.</p>
+            </div>
+            <a class="btn primary" href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+          </article>
+        </div>
+        <div class="entry-modes" aria-label="Alternate entry modes">
+          <h4>Non-linear entry options</h4>
+          <p class="small muted">Start wherever you need—mission-first, inventory-first, or RF-first—and the MissionProject JSON keeps everything in sync.</p>
+          <div class="entry-diagram" role="img" aria-label="Mission-first, inventory-first, and RF-first entry options">
+            <div class="entry-node">Mission-first<div class="entry-sub">Mission Architect → rest of stack</div></div>
+            <div class="entry-node">Inventory-first<div class="entry-sub">Node Architect → UxS → Mesh → Kits</div></div>
+            <div class="entry-node">RF-first<div class="entry-sub">Mesh Architect anchors coverage</div></div>
+          </div>
+        </div>
+      </div>
+
       <div class="card-grid" aria-label="Tool quick launch">
         <article class="card">
           <div>
             <h3>Node Architect</h3>
             <p>Define sensing nodes, payload stacks, and deployment envelopes from inventory or greenfield concepts.</p>
           </div>
-          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>UxS Architect</h3>
             <p>Pair nodes to unmanned air/ground/surface platforms with power, payload, and range checks.</p>
           </div>
-          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-UxS-Architect/web/" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>Mesh Architect</h3>
             <p>Plan RF meshes, relays, and gateways to backhaul small teams and unmanned assets.</p>
           </div>
-          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Mesh-Architect/" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>KitSmith</h3>
             <p>Assemble sustainment kits, spares, and team loadouts tied to mission phases.</p>
           </div>
-          <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-KitSmith/" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>Mission Architect</h3>
             <p>Compose missions, phases, and constraints that drive the rest of the stack.</p>
           </div>
-          <a class="btn subtle" href="https://nbschultz97.github.io/Mission-Architect/" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
         </article>
+      </div>
+
+      <div class="whitefrost-panel" id="whitefrostPanel" hidden aria-live="polite">
+        <div class="panel-header">
+          <h3>WHITEFROST Demo Mode</h3>
+          <span class="badge">Fictional</span>
+        </div>
+        <p>Cold-weather, high-altitude remote area of operations with fictional partner units in a highlands corridor. Emphasis on low-cost, modular 3D-printed airframes and rucksack-level sustainment. This demo is generic and not tied to any real-world unit or country.</p>
+      </div>
+
+      <div class="missionproject-callout" aria-label="MissionProject JSON overview">
+        <h3>MissionProject exchange file</h3>
+        <p class="small">All Architect tools exchange the same <code>MissionProject</code> JSON. Top-level keys stay consistent so planners can hand off between mission, RF, and sustainment without retyping.</p>
+        <pre class="code-snippet"><code>{
+  "nodes": [],
+  "platforms": [],
+  "mesh_links": [],
+  "kits": [],
+  "mission": {},
+  "environment": {},
+  "constraints": []
+}</code></pre>
       </div>
 
     </section>
@@ -232,6 +314,7 @@
           <p class="eyebrow">Mission Workflow</p>
           <h2>One dashboard, four modules. Move missions without leaving the shell.</h2>
           <p class="lead">Stay on a single page to embed platform, mesh, mission, and kit planners. Update module status, keep a shared mission project JSON in localStorage, and export/import as you go.</p>
+          <p class="small muted demo-note">Demo requests stay here and on CeradonSystems.com. Embedded planners load directly without in-iframe request prompts.</p>
         </div>
       </div>
 
@@ -355,7 +438,7 @@
         <h2>Mission Architect – drive the stack from the mission down</h2>
         <p class="lead">Compose phases, AO constraints, timelines, and outputs that downstream tools consume. This hub links directly to the existing Mission Architect app.</p>
         <div class="mission-actions">
-          <a class="btn primary" href="https://nbschultz97.github.io/Mission-Architect/" target="_blank" rel="noopener">Open Mission Architect</a>
+          <a class="btn primary" href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open Mission Architect</a>
           <a class="btn ghost" href="/#/workflow">See integrated workflow</a>
         </div>
       </div>
@@ -378,14 +461,14 @@
               <li>Package sustainment in KitSmith aligned to each phase and team role.</li>
             </ol>
             <div class="quick-links">
-              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html" target="_blank" rel="noopener">Open Node Architect</a>
-              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-UxS-Architect/web/" target="_blank" rel="noopener">Open UxS Architect</a>
-              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-Mesh-Architect/" target="_blank" rel="noopener">Open Mesh Architect</a>
-              <a class="btn subtle" href="https://nbschultz97.github.io/Ceradon-KitSmith/" target="_blank" rel="noopener">Open KitSmith</a>
+              <a class="btn subtle" href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open Node Architect</a>
+              <a class="btn subtle" href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open UxS Architect</a>
+              <a class="btn subtle" href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open Mesh Architect</a>
+              <a class="btn subtle" href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open KitSmith</a>
             </div>
             <div class="quick-links">
-              <a class="btn ghost" href="https://nbschultz97.github.io/Mission-Architect/print.html" target="_blank" rel="noopener">Mission Architect print view</a>
-              <a class="btn ghost" href="https://nbschultz97.github.io/Ceradon-KitSmith/print.html" target="_blank" rel="noopener">KitSmith print view</a>
+              <a class="btn ghost" href="https://mission-architect.ceradonsystems.com/print.html?access_code=ARC-STACK-761" target="_blank" rel="noopener">Mission Architect print view</a>
+              <a class="btn ghost" href="https://kitsmith.ceradonsystems.com/print.html?access_code=ARC-STACK-761" target="_blank" rel="noopener">KitSmith print view</a>
             </div>
           </div>
         </div>
@@ -393,7 +476,7 @@
           <h3>Live preview</h3>
           <p class="small">Embedded view loads the existing Mission Architect app. If it does not load, use the primary button above.</p>
           <div class="embed-container">
-            <iframe title="Mission Architect" src="https://nbschultz97.github.io/Mission-Architect/" loading="lazy"></iframe>
+            <iframe title="Mission Architect" src="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" loading="lazy"></iframe>
           </div>
         </div>
       </div>
@@ -443,11 +526,11 @@
   <footer class="site-footer">
     <div class="footer-links">
       <a href="https://ceradonsystems.com" target="_blank" rel="noopener">CeradonSystems.com</a>
-      <a href="https://nbschultz97.github.io/Ceradon-Node-Architect/web/index.html" target="_blank" rel="noopener">Node Architect</a>
-      <a href="https://nbschultz97.github.io/Ceradon-UxS-Architect/web/" target="_blank" rel="noopener">UxS Architect</a>
-      <a href="https://nbschultz97.github.io/Ceradon-Mesh-Architect/" target="_blank" rel="noopener">Mesh Architect</a>
-      <a href="https://nbschultz97.github.io/Ceradon-KitSmith/" target="_blank" rel="noopener">KitSmith</a>
-      <a href="https://nbschultz97.github.io/Mission-Architect/" target="_blank" rel="noopener">Mission Architect</a>
+      <a href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Node Architect</a>
+      <a href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">UxS Architect</a>
+      <a href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Mesh Architect</a>
+      <a href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">KitSmith</a>
+      <a href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Mission Architect</a>
     </div>
     <p class="small">Ceradon Systems LLC – Covert sensing, RF, and UxS planning tools.</p>
   </footer>


### PR DESCRIPTION
## Summary
- rewrite hub hero and toolchain around the fictional Project WHITEFROST demo and new ceradonsystems.com deep links
- add WHITEFROST demo mode toggle, scenario callouts, and MissionProject JSON overview for public-safe context
- simplify workflow guidance with centralized demo-request messaging and responsive toolchain/entry diagrams

## Testing
- not run (static content only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937a0ad6b5c8328800659d843bfd3ff)