### PR TITLE
Update Architect tool links to correct domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ This repo is the front-door, static SPA hub for the Ceradon Architect tools, pub
 - Sample demo: `data/demo_mission_project.json` provides a neutral COTS planning scenario with TAK-ready exports.
 
 ## Tool deep links
-- Node Architect: <https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
-- UxS Architect: <https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
-- Mesh Architect: <https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
-- KitSmith: <https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761>
-- Mission Architect: <https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761>
+- Node Architect: <https://node.architect.ceradonsystems.com/>
+- UxS Architect: <https://uxs.architect.ceradonsystems.com/>
+- Mesh Architect: <https://mesh.architect.ceradonsystems.com/>
+- KitSmith: <https://kitsmith.ceradonsystems.com/>
+- Mission Architect: <https://mission.architect.ceradonsystems.com/>
 
 ## Notes
 - The site is fully static and GitHub Pages–compatible; no backend or build tooling is required.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10,7 +10,7 @@ const toolData = [
     description: 'Mission-first entry point for phases, AO geometry, and constraints that drive the rest of the stack.',
     status: 'Live demo',
     badges: ['Mission composition', 'JSON export'],
-    link: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
+    link: 'https://mission.architect.ceradonsystems.com/'
   },
   {
     name: 'Node Architect',
@@ -18,7 +18,7 @@ const toolData = [
     description: 'Define sensing nodes, payload stacks, power envelopes, and deployment conditions.',
     status: 'Live demo',
     badges: ['Node planning', 'Payload design'],
-    link: 'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
+    link: 'https://node.architect.ceradonsystems.com/'
   },
   {
     name: 'UxS Architect',
@@ -26,7 +26,7 @@ const toolData = [
     description: 'Pair nodes to UxS platforms (air/ground/surface) with loadouts and sortie timing.',
     status: 'Live demo',
     badges: ['Platform design', 'Loadouts'],
-    link: 'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
+    link: 'https://uxs.architect.ceradonsystems.com/'
   },
   {
     name: 'Mesh Architect',
@@ -34,7 +34,7 @@ const toolData = [
     description: 'Shape RF meshes, relays, and gateways for contested environments.',
     status: 'Live demo',
     badges: ['Mesh / RF', 'Coverage'],
-    link: 'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761'
+    link: 'https://mesh.architect.ceradonsystems.com/'
   },
   {
     name: 'KitSmith',
@@ -42,7 +42,7 @@ const toolData = [
     description: 'Build kits, spares, and sustainment loads aligned to mission phases and roles.',
     status: 'Live demo',
     badges: ['Kits & sustainment', 'Resupply'],
-    link: 'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761'
+    link: 'https://kitsmith.ceradonsystems.com/'
   }
 ];
 
@@ -52,10 +52,10 @@ const workflowModules = [
     name: 'Platform Designer (Node + UxS)',
     category: 'Platform Designer',
     description: 'Shape sensing nodes and pair them with UxS lift. Keep payload, power, and sortie timing together.',
-    iframe: 'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+    iframe: 'https://node.architect.ceradonsystems.com/',
     links: [
-      { label: 'Open Node Architect', href: 'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761' },
-      { label: 'Open UxS Architect', href: 'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761' }
+      { label: 'Open Node Architect', href: 'https://node.architect.ceradonsystems.com/' },
+      { label: 'Open UxS Architect', href: 'https://uxs.architect.ceradonsystems.com/' }
     ]
   },
   {
@@ -63,9 +63,9 @@ const workflowModules = [
     name: 'Mesh Planner',
     category: 'Mesh Planner',
     description: 'Plan relays, LOS/NLOS links, and coverage so critical links stay redundant.',
-    iframe: 'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+    iframe: 'https://mesh.architect.ceradonsystems.com/',
     links: [
-      { label: 'Open Mesh Architect', href: 'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761' }
+      { label: 'Open Mesh Architect', href: 'https://mesh.architect.ceradonsystems.com/' }
     ]
   },
   {
@@ -73,10 +73,10 @@ const workflowModules = [
     name: 'Mission Planner',
     category: 'Mission Planner',
     description: 'Mission Architect drives phases, AO constraints, and exports that feed every downstream tool.',
-    iframe: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+    iframe: 'https://mission.architect.ceradonsystems.com/',
     links: [
-      { label: 'Open Mission Architect', href: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761' },
-      { label: 'Mission Architect print view', href: 'https://mission-architect.ceradonsystems.com/print.html?access_code=ARC-STACK-761' }
+      { label: 'Open Mission Architect', href: 'https://mission.architect.ceradonsystems.com/' },
+      { label: 'Mission Architect print view', href: 'https://mission.architect.ceradonsystems.com/print.html' }
     ]
   },
   {
@@ -84,10 +84,10 @@ const workflowModules = [
     name: 'KitSmith',
     category: 'KitSmith',
     description: 'Sustainment packaging, batteries, and per-person loads tied to mission phases.',
-    iframe: 'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761',
+    iframe: 'https://kitsmith.ceradonsystems.com/',
     links: [
-      { label: 'Open KitSmith', href: 'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761' },
-      { label: 'KitSmith print view', href: 'https://kitsmith.ceradonsystems.com/print.html?access_code=ARC-STACK-761' }
+      { label: 'Open KitSmith', href: 'https://kitsmith.ceradonsystems.com/' },
+      { label: 'KitSmith print view', href: 'https://kitsmith.ceradonsystems.com/print.html' }
     ]
   }
 ];
@@ -99,12 +99,12 @@ const demoStories = [
     flow: 'Mission Architect → Node Architect → UxS Architect → Mesh Architect → KitSmith',
     outputs: 'Light UxS, lean relays, and kit packaging tied together by MissionProject JSON.',
     links: {
-      mission: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+      mission: 'https://mission.architect.ceradonsystems.com/',
       tools: [
-        'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
-        'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
-        'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
-        'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761'
+        'https://node.architect.ceradonsystems.com/',
+        'https://uxs.architect.ceradonsystems.com/',
+        'https://mesh.architect.ceradonsystems.com/',
+        'https://kitsmith.ceradonsystems.com/'
       ]
     }
   },
@@ -114,13 +114,13 @@ const demoStories = [
     flow: 'Mesh Architect → Mission Architect → Node Architect → UxS Architect → KitSmith',
     outputs: 'RF survey-driven relays, constrained phases, small quad loadouts, and lean sustainment.',
     links: {
-      mission: 'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
+      mission: 'https://mission.architect.ceradonsystems.com/',
       tools: [
-        'https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
-        'https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
-        'https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
-        'https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761',
-        'https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761'
+        'https://mesh.architect.ceradonsystems.com/',
+        'https://mission.architect.ceradonsystems.com/',
+        'https://node.architect.ceradonsystems.com/',
+        'https://uxs.architect.ceradonsystems.com/',
+        'https://kitsmith.ceradonsystems.com/'
       ]
     }
   }

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
               <h3>Node Architect</h3>
               <p>Outline sensing nodes, payload stacks, and power envelopes for field hides and relay sites.</p>
             </div>
-            <a class="btn primary" href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+            <a class="btn primary" href="https://node.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch Demo</a>
           </article>
           <article class="step-card">
             <div>
@@ -205,7 +205,7 @@
               <h3>UxS Architect</h3>
               <p>Pair the nodes to low-cost airframes, check lift/power margins, and keep sorties aligned to terrain.</p>
             </div>
-            <a class="btn primary" href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+            <a class="btn primary" href="https://uxs.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch Demo</a>
           </article>
           <article class="step-card">
             <div>
@@ -213,7 +213,7 @@
               <h3>Mesh Architect</h3>
               <p>Plan relays, mesh redundancy, and RF entry points tailored to the mission environment.</p>
             </div>
-            <a class="btn primary" href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+            <a class="btn primary" href="https://mesh.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch Demo</a>
           </article>
           <article class="step-card">
             <div>
@@ -221,7 +221,7 @@
               <h3>KitSmith</h3>
               <p>Package ruck-level spares, batteries, and field repairs that match sortie plans.</p>
             </div>
-            <a class="btn primary" href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+            <a class="btn primary" href="https://kitsmith.ceradonsystems.com/" target="_blank" rel="noopener">Launch Demo</a>
           </article>
           <article class="step-card">
             <div>
@@ -229,7 +229,7 @@
               <h3>Mission Architect</h3>
               <p>Drive phases, constraints, and overlays that keep every downstream tool aligned.</p>
             </div>
-            <a class="btn primary" href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch Demo</a>
+            <a class="btn primary" href="https://mission.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch Demo</a>
           </article>
         </div>
         <div class="entry-modes" aria-label="Alternate entry modes">
@@ -249,35 +249,35 @@
             <h3>Node Architect</h3>
             <p>Define sensing nodes, payload stacks, and deployment envelopes from inventory or greenfield concepts.</p>
           </div>
-          <a class="btn subtle" href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://node.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>UxS Architect</h3>
             <p>Pair nodes to unmanned air/ground/surface platforms with power, payload, and range checks.</p>
           </div>
-          <a class="btn subtle" href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://uxs.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>Mesh Architect</h3>
             <p>Plan RF meshes, relays, and gateways to backhaul small teams and unmanned assets.</p>
           </div>
-          <a class="btn subtle" href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://mesh.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>KitSmith</h3>
             <p>Assemble sustainment kits, spares, and team loadouts tied to mission phases.</p>
           </div>
-          <a class="btn subtle" href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://kitsmith.ceradonsystems.com/" target="_blank" rel="noopener">Launch</a>
         </article>
         <article class="card">
           <div>
             <h3>Mission Architect</h3>
             <p>Compose missions, phases, and constraints that drive the rest of the stack.</p>
           </div>
-          <a class="btn subtle" href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Launch</a>
+          <a class="btn subtle" href="https://mission.architect.ceradonsystems.com/" target="_blank" rel="noopener">Launch</a>
         </article>
       </div>
 
@@ -443,7 +443,7 @@
         <h2>Mission Architect – drive the stack from the mission down</h2>
         <p class="lead">Compose phases, AO constraints, timelines, and outputs that downstream tools consume. This hub links directly to the existing Mission Architect app.</p>
         <div class="mission-actions">
-          <a class="btn primary" href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open Mission Architect</a>
+          <a class="btn primary" href="https://mission.architect.ceradonsystems.com/" target="_blank" rel="noopener">Open Mission Architect</a>
           <a class="btn ghost" href="/#/workflow">See integrated workflow</a>
         </div>
       </div>
@@ -466,14 +466,14 @@
               <li>Package sustainment in KitSmith aligned to each phase and team role.</li>
             </ol>
             <div class="quick-links">
-              <a class="btn subtle" href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open Node Architect</a>
-              <a class="btn subtle" href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open UxS Architect</a>
-              <a class="btn subtle" href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open Mesh Architect</a>
-              <a class="btn subtle" href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Open KitSmith</a>
+              <a class="btn subtle" href="https://node.architect.ceradonsystems.com/" target="_blank" rel="noopener">Open Node Architect</a>
+              <a class="btn subtle" href="https://uxs.architect.ceradonsystems.com/" target="_blank" rel="noopener">Open UxS Architect</a>
+              <a class="btn subtle" href="https://mesh.architect.ceradonsystems.com/" target="_blank" rel="noopener">Open Mesh Architect</a>
+              <a class="btn subtle" href="https://kitsmith.ceradonsystems.com/" target="_blank" rel="noopener">Open KitSmith</a>
             </div>
             <div class="quick-links">
-              <a class="btn ghost" href="https://mission-architect.ceradonsystems.com/print.html?access_code=ARC-STACK-761" target="_blank" rel="noopener">Mission Architect print view</a>
-              <a class="btn ghost" href="https://kitsmith.ceradonsystems.com/print.html?access_code=ARC-STACK-761" target="_blank" rel="noopener">KitSmith print view</a>
+              <a class="btn ghost" href="https://mission.architect.ceradonsystems.com/print.html" target="_blank" rel="noopener">Mission Architect print view</a>
+              <a class="btn ghost" href="https://kitsmith.ceradonsystems.com/print.html" target="_blank" rel="noopener">KitSmith print view</a>
             </div>
           </div>
         </div>
@@ -481,7 +481,7 @@
           <h3>Live preview</h3>
           <p class="small">Embedded view loads the existing Mission Architect app. If it does not load, use the primary button above.</p>
           <div class="embed-container">
-            <iframe title="Mission Architect" src="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" loading="lazy"></iframe>
+            <iframe title="Mission Architect" src="https://mission.architect.ceradonsystems.com/" loading="lazy"></iframe>
           </div>
         </div>
       </div>
@@ -531,11 +531,11 @@
   <footer class="site-footer">
     <div class="footer-links">
       <a href="https://ceradonsystems.com" target="_blank" rel="noopener">CeradonSystems.com</a>
-      <a href="https://node-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Node Architect</a>
-      <a href="https://uxs-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">UxS Architect</a>
-      <a href="https://mesh-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Mesh Architect</a>
-      <a href="https://kitsmith.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">KitSmith</a>
-      <a href="https://mission-architect.ceradonsystems.com/?access_code=ARC-STACK-761" target="_blank" rel="noopener">Mission Architect</a>
+      <a href="https://node.architect.ceradonsystems.com/" target="_blank" rel="noopener">Node Architect</a>
+      <a href="https://uxs.architect.ceradonsystems.com/" target="_blank" rel="noopener">UxS Architect</a>
+      <a href="https://mesh.architect.ceradonsystems.com/" target="_blank" rel="noopener">Mesh Architect</a>
+      <a href="https://kitsmith.ceradonsystems.com/" target="_blank" rel="noopener">KitSmith</a>
+      <a href="https://mission.architect.ceradonsystems.com/" target="_blank" rel="noopener">Mission Architect</a>
     </div>
     <p class="small">Ceradon Systems LLC – COTS-friendly RF and UxS planning tools.</p>
   </footer>


### PR DESCRIPTION
## Summary
- point Architect tool links to the correct *.architect.ceradonsystems.com endpoints
- remove demo access codes from public-facing URLs across the site and docs

## Testing
- not run (not necessary for link updates)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938982f6ad88328b113a556a58eec26)