### PR TITLE
Add schema validation console and taxonomy-driven presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Ceradon Architect Hub – Change Log
+
+## v1.3.0 – 2024-11-05
+- Hardened the demo access gate (client-side validation, no public code display, localStorage grant flag).
+- Added schema validation console in Docs with MissionProject JSON paste/apply flow.
+- Published canonical environment/EW taxonomy and wired workflow metadata to the shared enums.
+- Added mission archetype presets (WHITEFROST ridge, urban high-EW lane, partner sustainment, low-infrastructure mesh).
+- Surfaced Architect Hub Web v1.3 versioning in UI and documentation.
+
+## v0.4.0 – 2024-06-06
+- Added version and schema badges with mirrored footer metadata.
+- Introduced access overlays, status cards, and timestamps for MissionProject.
+- Consolidated modules/workflows copy and added a collapsible change log.
+
+## v0.3.1 – 2024-05-20
+- Refined MissionProject validation, summaries, and schema warnings.
+- Improved embedded workflow navigation and module status tracking.
+
+## v0.3.0 – 2024-05-05
+- Initial static hub with MissionProject storage, exports, and tool launchers.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -478,6 +478,11 @@ h1, h2, h3, h4 {
   text-decoration: none;
 }
 
+.btn.full {
+  width: 100%;
+  justify-content: flex-start;
+}
+
 .btn.primary {
   background: linear-gradient(135deg, var(--accent), var(--accent-strong));
   color: #0c111a;
@@ -1059,6 +1064,36 @@ h1, h2, h3, h4 {
   padding: 8px 12px;
   background: rgba(248, 113, 113, 0.08);
   border-radius: 10px;
+}
+
+.validation-callout {
+  margin-top: 10px;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel);
+}
+
+.validation-callout.success {
+  border-color: #2dd4bf;
+  background: rgba(45, 212, 191, 0.1);
+  color: #befae0;
+}
+
+.validation-callout.alert {
+  border-color: #f87171;
+  background: rgba(248, 113, 113, 0.08);
+  color: #fecdd3;
+}
+
+.archetype-list {
+  display: grid;
+  gap: 12px;
+}
+
+.archetype-row {
+  display: grid;
+  gap: 6px;
 }
 
 .small {

--- a/assets/js/mission_project.js
+++ b/assets/js/mission_project.js
@@ -23,7 +23,7 @@ const MissionProjectStore = (() => {
       origin_tool: 'hub',
       scenario: '',
       inventoryReference: 'Pending catalog reference',
-      accessCode: 'ARC-STACK-761',
+      accessCode: 'Request via Ceradon',
       team: { size: 0, roles: [] }
     },
     environment: [

--- a/data/demo_mission_project.json
+++ b/data/demo_mission_project.json
@@ -8,7 +8,7 @@
     "origin_tool": "hub",
     "scenario": "Sample training lane",
     "inventoryReference": "DEMO-COTS-001",
-    "accessCode": "ARC-STACK-761",
+    "accessCode": "Request via Ceradon",
     "team": { "size": 4, "roles": ["Team lead", "UxS operator", "Payload tech", "Mesh lead"] }
   },
   "environment": [

--- a/data/environment_taxonomy.json
+++ b/data/environment_taxonomy.json
@@ -1,0 +1,33 @@
+{
+  "environmentBands": [
+    { "value": "indoor", "label": "Indoor" },
+    { "value": "dense_urban", "label": "Dense urban" },
+    { "value": "urban", "label": "Urban" },
+    { "value": "suburban", "label": "Suburban" },
+    { "value": "rural", "label": "Rural" },
+    { "value": "open", "label": "Open / sparsely settled" }
+  ],
+  "altitudeBands": [
+    { "value": "0-500m", "label": "0–500m" },
+    { "value": "500-1500m", "label": "500–1500m" },
+    { "value": "1500-2500m", "label": "1500–2500m" },
+    { "value": ">2500m", "label": ">2500m" }
+  ],
+  "temperatureBands": [
+    { "value": "-30--10C", "label": "-30 to -10°C" },
+    { "value": "-10-10C", "label": "-10 to 10°C" },
+    { "value": "10-25C", "label": "10 to 25°C" },
+    { "value": "25-40C", "label": "25 to 40°C" }
+  ],
+  "ewLevels": [
+    { "value": "permissive", "label": "Permissive" },
+    { "value": "contested", "label": "Contested" },
+    { "value": "high-ew", "label": "High-EW" }
+  ],
+  "missionTypes": [
+    { "value": "mesh_recon", "label": "Mesh reconnaissance" },
+    { "value": "urban_lane", "label": "Urban mesh lane" },
+    { "value": "sustainment", "label": "Partner sustainment" },
+    { "value": "low_infrastructure", "label": "Low-infrastructure mesh" }
+  ]
+}

--- a/data/preset_low_infrastructure.json
+++ b/data/preset_low_infrastructure.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": "2.0.0",
+  "projectId": "mission-low-infra",
+  "meta": {
+    "name": "Mongolia low-infrastructure UxS + node mesh",
+    "description": "Sparse infrastructure mesh across open terrain and high-altitude routes.",
+    "durationHours": 120,
+    "origin_tool": "hub",
+    "scenario": "Low infrastructure range",
+    "inventoryReference": "MONGOLIA-MESH-LITE",
+    "missionType": "low_infrastructure",
+    "team": { "size": 7, "roles": ["Team lead", "Mesh lead", "UxS pilot", "Node tech", "Power lead", "Navigator", "Safety"] }
+  },
+  "environment": [
+    {
+      "id": "env-steppe",
+      "name": "High steppe",
+      "band": "open",
+      "altitudeBand": "1500-2500m",
+      "temperatureBand": "10-25C",
+      "weather": "Dry, high winds",
+      "terrain": "steppe",
+      "origin_tool": "hub",
+      "notes": "Long-range hops between sparse nodes"
+    }
+  ],
+  "constraints": [
+    { "id": "c-power", "type": "Power", "description": "Limited grid access along routes", "severity": "medium", "origin_tool": "mission" }
+  ],
+  "nodes": [
+    { "id": "node-steppe", "name": "Steppe node", "role": "sensor node", "rf": { "band": "UHF", "powerW": 4 }, "origin_tool": "node" }
+  ],
+  "platforms": [
+    { "id": "platform-uxs", "name": "Fixed-wing UAS", "role": "Long-haul lift", "origin_tool": "uxs" }
+  ],
+  "mesh_links": [
+    { "id": "mesh-steppe", "name": "Steppe mesh", "role": "backhaul", "origin_tool": "mesh" }
+  ],
+  "kits": [],
+  "mission": {
+    "tasks": [
+      { "id": "task-survey", "name": "Route survey", "description": "Confirm routes and relay points", "origin_tool": "mission" }
+    ],
+    "phases": [
+      { "id": "phase-survey-steppe", "name": "Survey", "durationHours": 24, "focus": "Scout routes", "origin_tool": "mission" },
+      { "id": "phase-operate", "name": "Operations", "durationHours": 72, "focus": "Mesh sustainment", "origin_tool": "mission" }
+    ],
+    "assignments": [
+      { "phaseId": "phase-operate", "nodeIds": ["node-steppe"], "platformIds": ["platform-uxs"] }
+    ],
+    "mission_cards": []
+  },
+  "sustainment": {
+    "sustainmentHours": 144,
+    "batteryCounts": 12,
+    "feasibility": {},
+    "notes": "Solar assist planned for long holds",
+    "power_plan": "",
+    "packing_lists": []
+  },
+  "meshPlan": {
+    "relayCount": 6,
+    "criticalLinks": 4,
+    "rf_bands": ["UHF", "L-band"],
+    "ew_profile": "permissive"
+  },
+  "kitsSummary": {
+    "perOperatorLoads": [],
+    "perOperatorLoadKg": 15,
+    "perOperatorLimitKg": 21
+  },
+  "exports": { "links": [], "notes": "" }
+}

--- a/data/preset_partner_sustainment.json
+++ b/data/preset_partner_sustainment.json
@@ -1,0 +1,71 @@
+{
+  "schemaVersion": "2.0.0",
+  "projectId": "mission-partner-sustainment",
+  "meta": {
+    "name": "Partner-force sustainment w/ 3D-printed UAS",
+    "description": "SOCPAC-style sustainment lane using partner UAS kits and mesh backhaul.",
+    "durationHours": 96,
+    "origin_tool": "hub",
+    "scenario": "Partner sustainment lane",
+    "inventoryReference": "SOCPAC-PARTNER-3DP",
+    "missionType": "sustainment",
+    "team": { "size": 8, "roles": ["Team lead", "Partner liaison", "Mesh lead", "UAS maintainer", "Payload tech", "Medic", "RTO", "Sustainment lead"] }
+  },
+  "environment": [
+    {
+      "id": "env-partner",
+      "name": "Coastal partner AO",
+      "band": "suburban",
+      "altitudeBand": "0-500m",
+      "temperatureBand": "10-25C",
+      "weather": "Maritime layer, light winds",
+      "terrain": "coastal", 
+      "origin_tool": "hub",
+      "notes": "Partner-operated sustainment nodes"
+    }
+  ],
+  "constraints": [],
+  "nodes": [
+    { "id": "node-partner-kit", "name": "Partner sustainment kit", "role": "resupply node", "rf": { "band": "L-band", "powerW": 5 }, "origin_tool": "node" }
+  ],
+  "platforms": [
+    { "id": "platform-3dp-uas", "name": "3D-printed UAS", "role": "Lift", "origin_tool": "uxs" }
+  ],
+  "mesh_links": [
+    { "id": "mesh-partner", "name": "Partner sustainment mesh", "role": "backhaul", "origin_tool": "mesh" }
+  ],
+  "kits": [],
+  "mission": {
+    "tasks": [
+      { "id": "task-resupply", "name": "Partner resupply", "description": "Deliver batteries and payloads via partner UAS", "origin_tool": "mission" }
+    ],
+    "phases": [
+      { "id": "phase-standup", "name": "Stand-up", "durationHours": 12, "focus": "Mesh deployment", "origin_tool": "mission" },
+      { "id": "phase-sustain", "name": "Sustainment", "durationHours": 72, "focus": "Continuous resupply", "origin_tool": "mission" }
+    ],
+    "assignments": [
+      { "phaseId": "phase-sustain", "nodeIds": ["node-partner-kit"], "platformIds": ["platform-3dp-uas"] }
+    ],
+    "mission_cards": []
+  },
+  "sustainment": {
+    "sustainmentHours": 120,
+    "batteryCounts": 14,
+    "feasibility": {},
+    "notes": "Partner batteries staged at checkpoints",
+    "power_plan": "",
+    "packing_lists": []
+  },
+  "meshPlan": {
+    "relayCount": 5,
+    "criticalLinks": 3,
+    "rf_bands": ["L-band", "S-band"],
+    "ew_profile": "contested"
+  },
+  "kitsSummary": {
+    "perOperatorLoads": [],
+    "perOperatorLoadKg": 17,
+    "perOperatorLimitKg": 22
+  },
+  "exports": { "links": [], "notes": "" }
+}

--- a/data/preset_urban_high_ew.json
+++ b/data/preset_urban_high_ew.json
@@ -1,0 +1,73 @@
+{
+  "schemaVersion": "2.0.0",
+  "projectId": "mission-urban-ew",
+  "meta": {
+    "name": "Urban mesh lane under high EW",
+    "description": "Dense-urban mesh lane with aggressive EW, hardened relays, and short sorties.",
+    "durationHours": 36,
+    "origin_tool": "hub",
+    "scenario": "High-EW lane demo",
+    "inventoryReference": "URBAN-EW-STACK",
+    "missionType": "urban_lane",
+    "team": { "size": 5, "roles": ["Mesh lead", "EW watch", "UxS pilot", "Relay tech", "Safety lead"] }
+  },
+  "environment": [
+    {
+      "id": "env-urban",
+      "name": "Dense urban core",
+      "band": "dense_urban",
+      "altitudeBand": "0-500m",
+      "temperatureBand": "25-40C",
+      "weather": "Humid, intermittent rain",
+      "terrain": "dense urban",
+      "origin_tool": "hub",
+      "notes": "Antenna clutter and canyon effects"
+    }
+  ],
+  "constraints": [
+    { "id": "c-elevation", "type": "LOS", "description": "Line-of-sight breaks at intersections", "severity": "high", "origin_tool": "mission" }
+  ],
+  "nodes": [
+    { "id": "node-street-relay", "name": "Street-level relay", "role": "mesh relay", "rf": { "band": "C-band", "powerW": 6 }, "origin_tool": "node" }
+  ],
+  "platforms": [
+    { "id": "platform-quad", "name": "Quad w/ shielded radios", "role": "UxS", "origin_tool": "uxs" }
+  ],
+  "mesh_links": [
+    { "id": "mesh-lane", "name": "Urban lane mesh", "role": "lane coverage", "origin_tool": "mesh" }
+  ],
+  "kits": [],
+  "mission": {
+    "tasks": [
+      { "id": "task-lane", "name": "Secure lane coverage", "description": "Maintain link despite jamming", "origin_tool": "mission" }
+    ],
+    "phases": [
+      { "id": "phase-survey", "name": "Survey", "durationHours": 6, "focus": "Find LOS gaps", "origin_tool": "mission" },
+      { "id": "phase-lane", "name": "Lane operation", "durationHours": 24, "focus": "Hold relays", "origin_tool": "mission" }
+    ],
+    "assignments": [
+      { "phaseId": "phase-lane", "nodeIds": ["node-street-relay"], "platformIds": ["platform-quad"] }
+    ],
+    "mission_cards": []
+  },
+  "sustainment": {
+    "sustainmentHours": 48,
+    "batteryCounts": 10,
+    "feasibility": {},
+    "notes": "Hot-weather spare battery rotation",
+    "power_plan": "",
+    "packing_lists": []
+  },
+  "meshPlan": {
+    "relayCount": 4,
+    "criticalLinks": 3,
+    "rf_bands": ["C-band", "L-band"],
+    "ew_profile": "high-ew"
+  },
+  "kitsSummary": {
+    "perOperatorLoads": [],
+    "perOperatorLoadKg": 16,
+    "perOperatorLimitKg": 21
+  },
+  "exports": { "links": [], "notes": "" }
+}

--- a/data/preset_whitefrost.json
+++ b/data/preset_whitefrost.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": "2.0.0",
+  "projectId": "mission-whitefrost",
+  "meta": {
+    "name": "WHITEFROST ridge recon mesh",
+    "description": "Cold-weather ridge recon mesh with neutral WHITEFROST payloads and redundant relays.",
+    "durationHours": 72,
+    "origin_tool": "hub",
+    "scenario": "Snowy ridgeline demo",
+    "inventoryReference": "WHITEFROST-KIT-01",
+    "missionType": "mesh_recon",
+    "team": { "size": 6, "roles": ["Team lead", "Mesh lead", "UAS operator", "Relay tech", "EW watch", "Partner liaison"] }
+  },
+  "environment": [
+    {
+      "id": "env-whitefrost",
+      "name": "Cold ridge line",
+      "band": "open",
+      "altitudeBand": "1500-2500m",
+      "temperatureBand": "-10-10C",
+      "weather": "Snow flurries, gusting winds",
+      "elevationM": 2100,
+      "terrain": "ridge",
+      "origin_tool": "hub",
+      "notes": "WHITEFROST demo alignment"
+    }
+  ],
+  "constraints": [
+    { "id": "c-ew", "type": "EW", "description": "Periodic jamming spikes near phase lines", "severity": "medium", "origin_tool": "mission" }
+  ],
+  "nodes": [
+    { "id": "node-ridge-relay", "name": "Ridge relay kit", "role": "mesh relay", "rf": { "band": "L/S", "powerW": 10 }, "origin_tool": "node" }
+  ],
+  "platforms": [
+    { "id": "platform-whitefrost-quad", "name": "Cold weather quad", "role": "UAS lift", "origin_tool": "uxs" }
+  ],
+  "mesh_links": [
+    { "id": "mesh-ridge", "name": "Ridge backhaul", "role": "relay", "origin_tool": "mesh" }
+  ],
+  "kits": [],
+  "mission": {
+    "tasks": [
+      { "id": "task-recon", "name": "Ridge reconnaissance", "description": "Confirm ridge movement lanes", "origin_tool": "mission" }
+    ],
+    "phases": [
+      { "id": "phase-insert", "name": "Insertion", "durationHours": 12, "focus": "Move relays", "origin_tool": "mission" },
+      { "id": "phase-ridge", "name": "Ridge hold", "durationHours": 48, "focus": "Mesh coverage", "origin_tool": "mission" }
+    ],
+    "assignments": [
+      { "phaseId": "phase-insert", "nodeIds": ["node-ridge-relay"], "platformIds": ["platform-whitefrost-quad"] }
+    ],
+    "mission_cards": []
+  },
+  "sustainment": {
+    "sustainmentHours": 96,
+    "batteryCounts": 8,
+    "feasibility": {},
+    "notes": "Cold weather spare packs and power buffers",
+    "power_plan": "",
+    "packing_lists": []
+  },
+  "meshPlan": {
+    "relayCount": 3,
+    "criticalLinks": 2,
+    "rf_bands": ["L-band", "S-band"],
+    "ew_profile": "contested"
+  },
+  "kitsSummary": {
+    "perOperatorLoads": [],
+    "perOperatorLoadKg": 18,
+    "perOperatorLimitKg": 22
+  },
+  "exports": { "links": [], "notes": "" }
+}

--- a/index.html
+++ b/index.html
@@ -133,12 +133,13 @@
     <div class="gate-stack">
       <div class="gate-shell" role="dialog" aria-labelledby="gateTitle" aria-describedby="gateDescription">
         <h1 id="gateTitle">Ceradon Systems — Architect Stack demos</h1>
-        <p id="gateDescription">Enter your demo access code to unlock the Architect Stack hub and launch tools in one place.</p>
+        <p id="gateDescription">Enter the access code provided by Ceradon Systems to unlock the Architect Stack hub and launch tools in one place.</p>
         <div class="gate-form">
           <label for="demo-code">Access code</label>
           <input id="demo-code" type="password" autocomplete="off" inputmode="numeric" aria-describedby="demo-error">
           <button id="demo-enter" type="button">Enter</button>
           <div id="demo-error" class="error-message" role="alert">Invalid code.</div>
+          <p class="small muted">Need a code? <a href="https://ceradonsystems.com/contact" target="_blank" rel="noopener">Request a demo code</a>.</p>
         </div>
       </div>
 
@@ -152,7 +153,10 @@
           <a
             id="demo-request-button"
             class="btn primary demo-request-btn"
-            href="mailto:contact@ceradonsystems.com?subject=Demo%20code%20request%20%E2%80%93%20Ceradon%20Architect%20Stack&body=Hi%20Ceradon%20team,%0D%0A%0D%0AI%27d%20like%20to%20request%20a%20demo%20access%20code%20for%20the%20Architect%20Stack.%0D%0A%0D%0AOrganization:%20%0D%0AUse%20case:%20%0D%0ATimeline:%20%0D%0A%0D%0AThank%20you.">
+            href="https://ceradonsystems.com/contact"
+            target="_blank"
+            rel="noopener"
+          >
             Request a demo code
           </a>
 
@@ -406,19 +410,17 @@
                     <label>Mission name
                       <input type="text" id="missionName" name="missionName" autocomplete="off">
                     </label>
+                    <label>Mission type (taxonomy)
+                      <select id="missionType" name="missionType"></select>
+                    </label>
+                    <label>Operating environment band
+                      <select id="environmentBand" name="environmentBand"></select>
+                    </label>
                     <label>Environment – altitude band
-                      <select id="altitudeBand" name="altitudeBand">
-                        <option value="0-1000m">0-1000m</option>
-                        <option value="1000-2500m">1000-2500m</option>
-                        <option value=">2500m">&gt;2500m</option>
-                      </select>
+                      <select id="altitudeBand" name="altitudeBand"></select>
                     </label>
                     <label>Environment – temperature band
-                      <select id="temperatureBand" name="temperatureBand">
-                        <option value="10-25C">10-25°C</option>
-                        <option value="-10-10C">-10 to 10°C</option>
-                        <option value="25-40C">25-40°C</option>
-                      </select>
+                      <select id="temperatureBand" name="temperatureBand"></select>
                     </label>
                     <label>Duration (hours)
                       <select id="durationHours" name="durationHours">
@@ -438,6 +440,9 @@
                     </label>
                     <label>Per-person weight limit (kg)
                       <input type="number" id="perPersonLimit" name="perPersonLimit" min="0" step="0.5">
+                    </label>
+                    <label>EW level (taxonomy)
+                      <select id="ewLevel" name="ewLevel"></select>
                     </label>
                     <label>Comms relay count
                       <input type="number" id="relayCount" name="relayCount" min="0" step="1">
@@ -548,6 +553,11 @@
             </div>
           </div>
         </div>
+        <div class="card">
+          <h3>Mission archetypes</h3>
+          <p class="small">Load doctrine-aligned MissionProject presets that mirror common Ceradon demo lanes.</p>
+          <div id="missionArchetypeList" class="archetype-list" aria-live="polite"></div>
+        </div>
         <div class="embed-card">
           <h3>Live preview</h3>
           <p class="small">Embedded view loads the existing Mission Architect app. If it does not load, use the primary button above.</p>
@@ -597,6 +607,31 @@
           <p class="small">All entities are tagged with <code>origin_tool</code> to ease cross-Architect imports. Exports remain offline-first and require no external APIs.</p>
         </div>
         <div class="card">
+          <h3>Schema &amp; Validation</h3>
+          <p>Paste a MissionProject JSON payload and validate it against the hub schema. Invalid payloads return JSON paths with issues.</p>
+          <p class="small" id="schemaVersionDisplay">MissionProject schema v2.0.0</p>
+          <textarea id="schemaValidatorInput" class="json-editor" rows="10" aria-label="MissionProject validation input"></textarea>
+          <div class="editor-actions">
+            <button class="btn subtle" id="schemaValidateBtn">Validate</button>
+            <button class="btn primary" id="schemaApplyBtn">Apply to workspace</button>
+            <a class="btn ghost" href="schema/mission_project_schema_v2.json" target="_blank" rel="noopener">Open schema file</a>
+          </div>
+          <div id="schemaValidationResult" class="validation-callout">Awaiting validation.</div>
+          <ul class="editor-status" id="schemaValidationErrors"></ul>
+        </div>
+        <div class="card">
+          <h3>Environment &amp; EW taxonomy</h3>
+          <p>Canonical environment bands, altitude and temperature ranges, EW levels, and mission types used across Architect tools. Workflow metadata selects from this shared list to keep planners aligned.</p>
+          <p class="small">Reference file: <code>data/environment_taxonomy.json</code>. Node, UxS, Mesh, and KitSmith are expected to mirror these enums.</p>
+          <ul class="bullet-list">
+            <li><strong>Environment bands:</strong> Indoor, dense urban, urban, suburban, rural, open.</li>
+            <li><strong>Altitude bands:</strong> 0–500m, 500–1500m, 1500–2500m, &gt;2500m.</li>
+            <li><strong>Temperature bands:</strong> -30 to -10°C, -10 to 10°C, 10 to 25°C, 25 to 40°C.</li>
+            <li><strong>EW levels:</strong> Permissive, contested, high-EW.</li>
+            <li><strong>Mission types:</strong> Mesh reconnaissance, urban lane, partner sustainment, low-infrastructure mesh.</li>
+          </ul>
+        </div>
+        <div class="card">
           <h3>How to use this with the other tools</h3>
           <ul class="bullet-list">
             <li><strong>Import/export:</strong> Each planner reads the same MissionProject JSON and should preserve unknown keys.</li>
@@ -639,7 +674,8 @@
   <script>
     (() => {
       const ACCESS_CODE = window.DEMO_ACCESS_CODE || "ARC-STACK-761";
-      const STORAGE_KEY = window.DEMO_ACCESS_KEY || "ceradon_demo_code";
+      const STORAGE_KEY = window.DEMO_ACCESS_KEY || "ceradon_architect_access_granted";
+      const LEGACY_KEY = window.LEGACY_ACCESS_KEY || "ceradon_demo_code";
       const gate = document.getElementById("access-gate");
       const appRoot = document.getElementById("app-root");
       const input = document.getElementById("demo-code");
@@ -648,20 +684,20 @@
 
       const accessBanner = document.getElementById("accessBanner");
 
-      function renderAccessBanner(code) {
+      function renderAccessBanner(isGranted) {
         if (!accessBanner) return;
-        if (!code) {
+        if (!isGranted) {
           accessBanner.hidden = true;
           accessBanner.textContent = '';
           return;
         }
-        accessBanner.textContent = `Active demo code: ${code}`;
+        accessBanner.textContent = 'Demo access granted — planners unlocked';
         accessBanner.hidden = false;
       }
 
-      function setLocked(isLocked, activeCode) {
+      function setLocked(isLocked) {
         document.body.classList.toggle("app-locked", isLocked);
-        renderAccessBanner(isLocked ? '' : activeCode);
+        renderAccessBanner(!isLocked);
         if (!isLocked && error) {
           error.style.display = "none";
           error.textContent = '';
@@ -671,8 +707,9 @@
       function handleAuth() {
         const value = (input?.value || "").trim();
         if (value === ACCESS_CODE) {
-          localStorage.setItem(STORAGE_KEY, ACCESS_CODE);
-          setLocked(false, ACCESS_CODE);
+          localStorage.setItem(STORAGE_KEY, 'true');
+          localStorage.removeItem(LEGACY_KEY);
+          setLocked(false);
           window.dispatchEvent(new Event("ceradon-demo-authorized"));
         } else {
           if (error) {
@@ -683,9 +720,12 @@
       }
 
       document.addEventListener("DOMContentLoaded", () => {
-        const storedValue = localStorage.getItem(STORAGE_KEY);
-        const authorized = storedValue === ACCESS_CODE || storedValue === "true";
-        setLocked(!authorized, authorized ? ACCESS_CODE : '');
+        const storedValue = localStorage.getItem(STORAGE_KEY) || localStorage.getItem(LEGACY_KEY);
+        const authorized = storedValue === "true" || storedValue === ACCESS_CODE;
+        if (authorized) {
+          localStorage.setItem(STORAGE_KEY, 'true');
+        }
+        setLocked(!authorized);
 
         window.applyWorkflowGuard?.();
 


### PR DESCRIPTION
## Summary
- Harden the demo access gate by validating against a shared constant, storing a grant flag, and removing code exposure in the UI while updating version metadata and changelog entries
- Add a Docs-based schema validation console, reuse the detailed validator on imports, and drive workflow metadata selectors from the shared environment/EW taxonomy
- Publish canonical taxonomy and mission archetype preset data files to keep MissionProject templates aligned across planners

## Testing
- python -m json.tool data/environment_taxonomy.json data/preset_whitefrost.json data/preset_urban_high_ew.json data/preset_partner_sustainment.json data/preset_low_infrastructure.json data/demo_mission_project.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a7af420c832896d03c1e034db153)