### PR TITLE
Redesign marketing page as offline app playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,71 @@
-# Ceradon Architect Stack
+# Ceradon Architect - Offline Mission Planning Tool
 
-**Offline-First Mission Planning Tool for Special Operations Forces**
+**Fully Offline Mission Planning for Air-Gapped Environments**
 
-The Ceradon Architect Stack is a professional, offline-capable web application designed for use in air-gapped, contested environments. It functions as a "Digital Construction Foreman," enabling small teams to virtually design, validate, and sustain custom small unmanned systems (sUAS) using commercial off-the-shelf (COTS) components before any physical assembly begins.
+Ceradon Architect is a professional, offline-first web application for sUAS mission planning in contested environments. Build custom platforms from COTS components, plan multi-day missions with logistics, and validate RF communications — entirely in your browser with zero cloud dependencies.
 
-Published via GitHub Pages at <https://nbschultz97.github.io/Ceradon-Architect/>. The authoritative MissionProject schema and Parts Library schema live here and surface throughout the UI.
+**Live Demo:** <https://architect.ceradonsystems.com> (GitHub Pages)
 
-## Quick start
-- Serve locally with any static file host (e.g., `python -m http.server 8000`) and open `http://localhost:8000`.
-- Navigate with hash routes: `/#/home`, `/#/workflow`, `/#/tools`, `/#/mission`, `/#/demos`, `/#/docs`.
-- Use the light/dark toggle in the nav to switch themes.
-- Open `/#/workflow` to reach the unified Mission Workflow dashboard with embedded tools, module status selectors, project import/export controls, and feasibility checks.
+## What's New (v2.0)
 
-## Updating content
-- **Theme tokens:** edit `assets/css/styles.css` (`:root` and `[data-theme="light"]`).
-- **Routes & views:** sections live in `index.html`; routing is in `assets/js/app.js`.
-- **Tools:** update the `toolData` array in `assets/js/app.js` to add or change tool cards.
-- **Workflow dashboard:** adjust the `workflowModules` array in `assets/js/app.js` to point the left-nav items to new URLs or change descriptions. The dashboard uses iframes by default to keep everything static-hostable.
-- **Demo stories:** edit the `demoStories` array in `assets/js/app.js`.
-- **Mission Architect embed:** update the iframe/link URL in the `mission` section of `index.html`.
+This is a **complete redesign** focused on making the offline tools the actual product, not just marketing links:
 
-## Mission Workflow dashboard
-- Navigate to `/#/workflow` to stay in one shell while operating the core modules:
-  - Platform Designer (Node + UxS Architect)
-  - Mesh Planner (Mesh Architect)
-  - Mission Planner (Mission Architect)
-  - KitSmith
-- Each module opens in an iframe with quick-launch links. A per-module status selector (Not Started / In Progress / Complete) is stored in `localStorage` under `ceradon_module_statuses`.
-- A mission project panel exposes shared metadata fields and import/export buttons to keep a single JSON object in sync across tools.
-- A feasibility panel reads the stored project JSON and highlights sustainment coverage, kit weight margins, and comms relay redundancy.
+- **Removed:** Access gates, external demo links, marketing content
+- **Added:** Full interactive UIs for all offline modules
+- **Focus:** Actual mission planning tool, not a demo hub
+
+## Quick Start
+
+```bash
+# Serve locally
+python -m http.server 8000
+# Open http://localhost:8000
+```
+
+Navigate with hash routes:
+- `/#/home` - Overview and quick start
+- `/#/library` - Parts Library (manage COTS components)
+- `/#/platform` - Platform Designer (build and validate platforms)
+- `/#/mission` - Mission Planner (phases, logistics, packing lists)
+- `/#/comms` - Comms Validator (RF link budgets, relay placement)
+- `/#/export` - Export mission packages (JSON, GeoJSON, CoT)
+
+## Application Structure
+
+### Frontend Modules
+- `index.html` - Single-page application with route-based views
+- `assets/js/app.js` - Main application logic, routing, and UI initialization
+- `assets/css/styles.css` - Theme system (dark/light mode)
+
+### Offline Planning Modules
+All modules operate entirely client-side with no external dependencies:
+
+1. **Parts Library** (`assets/js/parts_library.js`)
+   - IndexedDB storage for 1000+ COTS components
+   - CSV import for unit inventory
+   - Categories: airframes, motors, ESCs, batteries, flight controllers, radios, sensors, accessories
+
+2. **Platform Designer** (`assets/js/platform_designer.js`)
+   - Build virtual platforms from parts library components
+   - Real-time physics validation (thrust-to-weight, flight time)
+   - Environmental derating for altitude and temperature
+
+3. **Mission Planner** (`assets/js/mission_planner.js`)
+   - Define mission phases (ORP, infil, on-station, exfil)
+   - Calculate battery swap schedules
+   - Generate per-operator packing lists
+   - Terrain-adjusted weight limits
+
+4. **Comms Validator** (`assets/js/comms_validator.js`)
+   - RF link budget calculator
+   - Line-of-sight analysis
+   - Fresnel zone clearance
+   - Relay placement recommendations
+
+5. **Supporting Modules**
+   - `physics_engine.js` - Physics calculations and environmental modeling
+   - `csv_importer.js` - CSV parsing for bulk imports
+   - `mission_project.js` - MissionProject JSON store and validation
 
 ## MissionProject schema and helpers
 - MissionProject schema v2.0.0 is defined in `schema/mission_project_schema_v2.json` and described in `docs/mission_project_schema.md`. The UI surfaces the current version in a schema card and warns on mismatches.
@@ -42,12 +79,13 @@ Published via GitHub Pages at <https://nbschultz97.github.io/Ceradon-Architect/>
 - Sample demo: `data/demo_mission_project.json` provides a neutral COTS planning scenario with TAK-ready exports.
 - Data flow reference: `docs/stack_workflows.md` documents mission-first, kit-first, and RF-first chains and stresses preserving unknown fields when round-tripping.
 
-## Tool deep links
-- Node Architect: <https://node.ceradonsystems.com/web/index.html>
-- UxS Architect: <https://uxs.ceradonsystems.com/web/>
-- Mesh Architect: <https://mesh.ceradonsystems.com/>
-- KitSmith: <https://kitsmith.ceradonsystems.com/>
-- Mission Architect: <https://mission.ceradonsystems.com/>
+## Data Storage
+
+All data is stored locally in the browser:
+- **localStorage**: MissionProject JSON, user preferences, theme
+- **IndexedDB**: Parts Library catalog (efficient for 1000+ parts)
+
+No data ever leaves your device. Works completely offline in air-gapped environments.
 
 ---
 
@@ -397,13 +435,10 @@ MissionPlanner.downloadSummaryReport(mission);
 
 ---
 
-## Tool deep links
-- Node Architect: <https://node.ceradonsystems.com/web/index.html>
-- UxS Architect: <https://uxs.ceradonsystems.com/web/>
-- Mesh Architect: <https://mesh.ceradonsystems.com/>
-- KitSmith: <https://kitsmith.ceradonsystems.com/>
-- Mission Architect: <https://mission.ceradonsystems.com/>
+## Deployment
 
-## Notes
-- The site is fully static and GitHub Pages–compatible; no backend or build tooling is required.
-- New offline modules are completely self-contained and operate without external dependencies.
+The site is fully static and GitHub Pages-compatible:
+- No backend or build tooling required
+- Can be deployed to any static file host
+- Works offline once cached by the browser
+- All modules are self-contained JavaScript files

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,235 +1,14 @@
-// Ceradon Architect SPA
-// - Hash-based routes: home, workflow, tools, mission, demos, docs
-// - Theme tokens live in assets/css/styles.css
-// - Add new tools/demos by editing the data blocks below
+// Ceradon Architect - Offline Mission Planning Tool
+// Routes: home, library, platform, mission, comms, export
 
-const APP_VERSION = 'Architect Hub Web v1.3';
-const DEMO_ACCESS_CODE = 'ARC-STACK-761';
-const DEMO_ACCESS_KEY = 'ceradon_architect_access_granted';
-const LEGACY_ACCESS_KEY = 'ceradon_demo_code';
-const CHANGE_LOG = [
-  {
-    version: 'v1.3.0',
-    date: '2024-11-05',
-    changes: [
-      'Hardened the demo access gate with client-side validation, localStorage grant flag, and hidden code strings.',
-      'Added a schema validation console under Docs with MissionProject JSON paste + error surfaces.',
-      'Published canonical environment/EW taxonomy and wired workflow metadata to the shared enums.',
-      'Introduced mission archetype presets that load curated MissionProject templates.',
-      'Updated versioning to Architect Hub Web v1.3 and documented the release in CHANGELOG.md.'
-    ]
-  },
-  {
-    version: 'v0.4.0',
-    date: '2024-06-06',
-    changes: [
-      'Added version and schema badges with mirrored footer metadata.',
-      'Introduced access overlays, status cards, and timestamps for MissionProject.',
-      'Consolidated modules/workflows copy and added a collapsible change log.'
-    ]
-  },
-  {
-    version: 'v0.3.1',
-    date: '2024-05-20',
-    changes: [
-      'Refined MissionProject validation, summaries, and schema warnings.',
-      'Improved embedded workflow navigation and module status tracking.'
-    ]
-  },
-  {
-    version: 'v0.3.0',
-    date: '2024-05-05',
-    changes: [
-      'Initial static hub with MissionProject storage, exports, and tool launchers.'
-    ]
-  }
-];
+const APP_VERSION = 'Ceradon Architect v2.0 - Offline';
+const SCHEMA_VERSION = 'MissionProject v2.0.0';
 
-window.DEMO_ACCESS_CODE = DEMO_ACCESS_CODE;
-window.DEMO_ACCESS_KEY = DEMO_ACCESS_KEY;
-window.LEGACY_ACCESS_KEY = LEGACY_ACCESS_KEY;
+// ============================================================================
+// ROUTING
+// ============================================================================
 
-const toolData = [
-  {
-    name: 'Mission Architect',
-    type: 'Mission composition',
-    description: 'Mission-first entry point for phases, AO geometry, and constraints that drive the rest of the stack.',
-    status: 'Live demo',
-    badges: ['Mission composition', 'JSON export'],
-    link: 'https://mission.ceradonsystems.com/'
-  },
-  {
-    name: 'Node Architect',
-    type: 'Planning tool',
-    description: 'Define sensing nodes, payload stacks, power envelopes, and deployment conditions.',
-    status: 'Live demo',
-    badges: ['Node planning', 'Payload design'],
-    link: 'https://node.ceradonsystems.com/web/index.html'
-  },
-  {
-    name: 'UxS Architect',
-    type: 'Planning tool',
-    description: 'Pair nodes to UxS platforms (air/ground/surface) with loadouts and sortie timing.',
-    status: 'Live demo',
-    badges: ['Platform design', 'Loadouts'],
-    link: 'https://uxs.ceradonsystems.com/web/'
-  },
-  {
-    name: 'Mesh Architect',
-    type: 'RF tool',
-    description: 'Shape RF meshes, relays, and gateways for contested environments.',
-    status: 'Live demo',
-    badges: ['Mesh / RF', 'Coverage'],
-    link: 'https://mesh.ceradonsystems.com/'
-  },
-  {
-    name: 'KitSmith',
-    type: 'Planning tool',
-    description: 'Build kits, spares, and sustainment loads aligned to mission phases and roles.',
-    status: 'Live demo',
-    badges: ['Kits & sustainment', 'Resupply'],
-    link: 'https://kitsmith.ceradonsystems.com/'
-  }
-];
-
-const workflowModules = [
-  {
-    id: 'platform',
-    name: 'Platform Designer (Node + UxS)',
-    category: 'Platform Designer',
-    description: 'Shape sensing nodes and pair them with UxS lift. Keep payload, power, and sortie timing together.',
-    iframe: 'https://node.ceradonsystems.com/web/index.html',
-    links: [
-      { label: 'Open Node Architect', href: 'https://node.ceradonsystems.com/web/index.html' },
-      { label: 'Open UxS Architect', href: 'https://uxs.ceradonsystems.com/web/' }
-    ]
-  },
-  {
-    id: 'mesh',
-    name: 'Mesh Planner',
-    category: 'Mesh Planner',
-    description: 'Plan relays, LOS/NLOS links, and coverage so critical links stay redundant.',
-    iframe: 'https://mesh.ceradonsystems.com/',
-    links: [
-      { label: 'Open Mesh Architect', href: 'https://mesh.ceradonsystems.com/' }
-    ]
-  },
-  {
-    id: 'mission',
-    name: 'Mission Planner',
-    category: 'Mission Planner',
-    description: 'Mission Architect drives phases, AO constraints, and exports that feed every downstream tool.',
-    iframe: 'https://mission.ceradonsystems.com/',
-    links: [
-      { label: 'Open Mission Architect', href: 'https://mission.ceradonsystems.com/' },
-      { label: 'Mission Architect print view', href: 'https://mission.ceradonsystems.com/print.html' }
-    ]
-  },
-  {
-    id: 'kitsmith',
-    name: 'KitSmith',
-    category: 'KitSmith',
-    description: 'Sustainment packaging, batteries, and per-person loads tied to mission phases.',
-    iframe: 'https://kitsmith.ceradonsystems.com/',
-    links: [
-      { label: 'Open KitSmith', href: 'https://kitsmith.ceradonsystems.com/' },
-      { label: 'KitSmith print view', href: 'https://kitsmith.ceradonsystems.com/print.html' }
-    ]
-  }
-];
-
-const demoStories = [
-  {
-    name: 'Sample COTS sortie stack',
-    entry: 'Mission-first',
-    flow: 'Mission Architect → Node Architect → UxS Architect → Mesh Architect → KitSmith',
-    outputs: 'Light UxS, lean relays, and kit packaging tied together by MissionProject JSON.',
-    links: {
-      mission: 'https://mission.ceradonsystems.com/',
-      tools: [
-        'https://node.ceradonsystems.com/web/index.html',
-        'https://uxs.ceradonsystems.com/web/',
-        'https://mesh.ceradonsystems.com/',
-        'https://kitsmith.ceradonsystems.com/'
-      ]
-    }
-  },
-  {
-    name: 'Urban mesh in dense block',
-    entry: 'RF-environment-first',
-    flow: 'Mesh Architect → Mission Architect → Node Architect → UxS Architect → KitSmith',
-    outputs: 'RF survey-driven relays, constrained phases, small quad loadouts, and lean sustainment.',
-    links: {
-      mission: 'https://mission.ceradonsystems.com/',
-      tools: [
-        'https://mesh.ceradonsystems.com/',
-        'https://mission.ceradonsystems.com/',
-        'https://node.ceradonsystems.com/web/index.html',
-        'https://uxs.ceradonsystems.com/web/',
-        'https://kitsmith.ceradonsystems.com/'
-      ]
-    }
-  }
-];
-
-const missionArchetypes = [
-  {
-    id: 'whitefrost',
-    label: 'Cold-weather ridge recon mesh (WHITEFROST demo)',
-    path: 'data/preset_whitefrost.json',
-    description: 'High-altitude cold-weather ridge recon mesh with neutral WHITEFROST payloads.'
-  },
-  {
-    id: 'urban-lane',
-    label: 'Urban mesh lane under high EW',
-    path: 'data/preset_urban_high_ew.json',
-    description: 'Dense urban mesh lane with elevated EW profile and hard relays.'
-  },
-  {
-    id: 'partner-sustainment',
-    label: 'Partner-force sustainment w/ 3D-printed UAS (SOCPAC-style)',
-    path: 'data/preset_partner_sustainment.json',
-    description: 'Partner-force sustainment run with printed UAS sets and lean resupply windows.'
-  },
-  {
-    id: 'low-infrastructure',
-    label: 'Mongolia low-infrastructure UxS + node mesh',
-    path: 'data/preset_low_infrastructure.json',
-    description: 'Sparse infrastructure mesh for wide-open, high-altitude routes.'
-  }
-];
-
-const routes = ['home', 'workflow', 'tools', 'mission', 'demos', 'docs'];
-const MODULE_STATUS_KEY = 'ceradon_module_statuses';
-const moduleStatusOptions = ['Not Started', 'In Progress', 'Complete'];
-const DEMO_PROJECT_PATH = 'data/demo_mission_project.json';
-const LOAD_WARNING_MARGIN_KG = 2; // Small buffer before weight is flagged.
-const SUSTAINMENT_WARNING_BUFFER_HOURS = 6; // Hours of sustainment shortfall tolerated before alerting.
-let environmentTaxonomy = null;
-let highlightedTools = [];
-let moduleStatuses = {};
-let activeModuleId = workflowModules[0].id;
-let projectStatusMessage = '';
-let projectLoadSource = '';
-let editorErrors = [];
-
-const hasDemoAccess = () => {
-  const granted = localStorage.getItem(DEMO_ACCESS_KEY);
-  const legacy = localStorage.getItem(LEGACY_ACCESS_KEY);
-
-  if (granted === 'true') return true;
-  if (legacy === DEMO_ACCESS_CODE || legacy === 'true') {
-    localStorage.setItem(DEMO_ACCESS_KEY, 'true');
-    return true;
-  }
-  return false;
-};
-
-function formatTimestamp(value) {
-  if (!value) return 'Not set';
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? 'Not set' : date.toLocaleString();
-}
+const routes = ['home', 'library', 'platform', 'mission', 'comms', 'export'];
 
 function setActiveRoute(route) {
   const target = routes.includes(route) ? route : 'home';
@@ -242,6 +21,25 @@ function setActiveRoute(route) {
     const isActive = link.dataset.route === target;
     link.classList.toggle('active', isActive);
   });
+
+  // Initialize module when navigated to
+  switch (target) {
+    case 'library':
+      initPartsLibrary();
+      break;
+    case 'platform':
+      initPlatformDesigner();
+      break;
+    case 'mission':
+      initMissionPlanner();
+      break;
+    case 'comms':
+      initCommsValidator();
+      break;
+    case 'export':
+      initExport();
+      break;
+  }
 }
 
 function handleHashChange() {
@@ -249,1088 +47,614 @@ function handleHashChange() {
   setActiveRoute(hash);
 }
 
-async function loadEnvironmentTaxonomy() {
-  if (environmentTaxonomy) return environmentTaxonomy;
-  try {
-    const response = await fetch('data/environment_taxonomy.json');
-    if (!response.ok) {
-      throw new Error('Unable to load taxonomy');
-    }
-    environmentTaxonomy = await response.json();
-    return environmentTaxonomy;
-  } catch (error) {
-    console.warn('Falling back to default taxonomy', error);
-    environmentTaxonomy = {
-      environmentBands: [
-        { value: 'indoor', label: 'Indoor' },
-        { value: 'dense_urban', label: 'Dense urban' },
-        { value: 'urban', label: 'Urban' },
-        { value: 'suburban', label: 'Suburban' },
-        { value: 'rural', label: 'Rural' },
-        { value: 'open', label: 'Open / sparsely settled' }
-      ],
-      altitudeBands: [
-        { value: '0-500m', label: '0–500m' },
-        { value: '500-1500m', label: '500–1500m' },
-        { value: '1500-2500m', label: '1500–2500m' },
-        { value: '>2500m', label: '>2500m' }
-      ],
-      temperatureBands: [
-        { value: '-30--10C', label: '-30 to -10°C' },
-        { value: '-10-10C', label: '-10 to 10°C' },
-        { value: '10-25C', label: '10 to 25°C' },
-        { value: '25-40C', label: '25 to 40°C' }
-      ],
-      ewLevels: [
-        { value: 'permissive', label: 'Permissive' },
-        { value: 'contested', label: 'Contested' },
-        { value: 'high-ew', label: 'High-EW' }
-      ],
-      missionTypes: [
-        { value: 'mesh_recon', label: 'Mesh reconnaissance' },
-        { value: 'urban_lane', label: 'Urban mesh lane' },
-        { value: 'sustainment', label: 'Partner sustainment' },
-        { value: 'low_infrastructure', label: 'Low-infrastructure mesh' }
-      ]
-    };
-    return environmentTaxonomy;
-  }
-}
-
-function populateSelectOptions(selectEl, options = [], placeholder = 'Select an option') {
-  if (!selectEl) return;
-  selectEl.innerHTML = '';
-  if (placeholder) {
-    const emptyOpt = document.createElement('option');
-    emptyOpt.value = '';
-    emptyOpt.textContent = placeholder;
-    selectEl.appendChild(emptyOpt);
-  }
-  options.forEach((option) => {
-    const opt = document.createElement('option');
-    opt.value = option.value;
-    opt.textContent = option.label || option.value;
-    selectEl.appendChild(opt);
-  });
-}
-
-function ensureOption(selectEl, value) {
-  if (!selectEl || !value) return;
-  const exists = Array.from(selectEl.options).some((opt) => opt.value === value);
-  if (!exists) {
-    const opt = document.createElement('option');
-    opt.value = value;
-    opt.textContent = value;
-    selectEl.appendChild(opt);
-  }
-}
-
-async function applyTaxonomyToForms() {
-  const taxonomy = await loadEnvironmentTaxonomy();
-  const altitudeSelect = document.getElementById('altitudeBand');
-  const temperatureSelect = document.getElementById('temperatureBand');
-  const environmentSelect = document.getElementById('environmentBand');
-  const ewLevelSelect = document.getElementById('ewLevel');
-  const missionTypeSelect = document.getElementById('missionType');
-
-  populateSelectOptions(environmentSelect, taxonomy.environmentBands, 'Select environment band');
-  populateSelectOptions(altitudeSelect, taxonomy.altitudeBands, 'Select altitude band');
-  populateSelectOptions(temperatureSelect, taxonomy.temperatureBands, 'Select temperature band');
-  populateSelectOptions(ewLevelSelect, taxonomy.ewLevels, 'Select EW level');
-  populateSelectOptions(missionTypeSelect, taxonomy.missionTypes, 'Select mission type');
-}
-
-function renderVersionBadges(schemaVersion = MISSION_PROJECT_SCHEMA_VERSION) {
-  document.querySelectorAll('[data-app-version]').forEach((el) => {
-    el.textContent = APP_VERSION;
-  });
-  document.querySelectorAll('[data-schema-version]').forEach((el) => {
-    el.textContent = `MissionProject schema v${schemaVersion}`;
-  });
-}
-
-async function renderSchemaVersionMetadata() {
-  try {
-    const schema = await MissionProjectStore.fetchMissionProjectSchema();
-    const description = schema?.description || '';
-    const versionMatch = description.match(/v(\d+\.\d+\.\d+)/i);
-    const parsedVersion = versionMatch ? versionMatch[1] : (schema?.properties?.schemaVersion?.default || MISSION_PROJECT_SCHEMA_VERSION);
-    renderVersionBadges(parsedVersion);
-    const schemaVersionDisplay = document.getElementById('schemaVersionDisplay');
-    if (schemaVersionDisplay) {
-      schemaVersionDisplay.textContent = `MissionProject schema v${parsedVersion}`;
-    }
-  } catch (error) {
-    console.warn('Unable to resolve schema version from file', error);
-    renderVersionBadges();
-  }
-}
-
-function renderChangeLog() {
-  const container = document.getElementById('changeLogEntries');
-  if (!container) return;
-  container.innerHTML = '';
-
-  CHANGE_LOG.forEach((entry) => {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'change-log-entry';
-    wrapper.innerHTML = `
-      <div class="change-log-header">
-        <strong>${entry.version}</strong>
-        <span class="small muted">${entry.date}</span>
-      </div>
-      <ul class="change-log-list">${entry.changes.map((item) => `<li>${item}</li>`).join('')}</ul>
-    `;
-    container.appendChild(wrapper);
-  });
-}
-
-function buildTools() {
-  const grid = document.getElementById('toolGrid');
-  if (!grid) return;
-  grid.innerHTML = '';
-
-  toolData.forEach(tool => {
-    const card = document.createElement('article');
-    card.className = 'tool-card';
-    if (highlightedTools.includes(tool.name)) {
-      card.classList.add('highlight');
-    }
-    card.innerHTML = `
-      <div class="status ${tool.status.toLowerCase().replace(' ', '')}">${tool.status}</div>
-      <h3>${tool.name}</h3>
-      <p class="small">${tool.type}</p>
-      <p>${tool.description}</p>
-      <div class="badges">${tool.badges.map(b => `<span class="badge">${b}</span>`).join('')}</div>
-      <a class="btn primary" href="${tool.link}" target="_blank" rel="noopener">Open in new tab</a>
-    `;
-    grid.appendChild(card);
-  });
-}
-
-function buildDemos() {
-  const grid = document.getElementById('demoGrid');
-  if (!grid) return;
-  grid.innerHTML = '';
-
-  demoStories.forEach(demo => {
-    const card = document.createElement('div');
-    card.className = 'demo-card';
-    card.innerHTML = `
-      <h3>${demo.name}</h3>
-      <p class="small"><strong>Entry:</strong> ${demo.entry}</p>
-      <p class="small"><strong>Flow:</strong> ${demo.flow}</p>
-      <p>${demo.outputs}</p>
-    `;
-
-    const actions = document.createElement('div');
-    actions.className = 'demo-actions';
-
-    const openMission = document.createElement('a');
-    openMission.className = 'btn ghost';
-    openMission.textContent = 'Open Mission Architect';
-    openMission.href = demo.links.mission;
-    openMission.target = '_blank';
-    openMission.rel = 'noopener';
-    actions.appendChild(openMission);
-
-    const openTools = document.createElement('a');
-    openTools.className = 'btn subtle';
-    openTools.textContent = 'Open relevant tools';
-    openTools.href = '#';
-    openTools.addEventListener('click', (e) => {
-      e.preventDefault();
-      demo.links.tools.forEach(url => window.open(url, '_blank', 'noopener'));
-    });
-
-    actions.appendChild(openTools);
-    card.appendChild(actions);
-    grid.appendChild(card);
-  });
-}
-
-function renderMissionArchetypes() {
-  const container = document.getElementById('missionArchetypeList');
-  if (!container) return;
-  container.innerHTML = '';
-
-  missionArchetypes.forEach((archetype) => {
-    const button = document.createElement('button');
-    button.className = 'btn primary full';
-    button.type = 'button';
-    button.textContent = archetype.label;
-    button.setAttribute('aria-label', `${archetype.label} – ${archetype.description}`);
-    button.addEventListener('click', (event) => {
-      event.preventDefault();
-      loadArchetypeProject(archetype, button);
-    });
-
-    const wrapper = document.createElement('div');
-    wrapper.className = 'archetype-row';
-    wrapper.innerHTML = `<p class="small muted">${archetype.description}</p>`;
-    wrapper.prepend(button);
-    container.appendChild(wrapper);
-  });
-}
-
-function loadModuleStatuses() {
-  const stored = localStorage.getItem(MODULE_STATUS_KEY);
-  if (!stored) return {};
-  try {
-    return JSON.parse(stored) || {};
-  } catch (error) {
-    console.warn('Unable to parse module statuses, resetting', error);
-    return {};
-  }
-}
-
-function saveModuleStatuses(statuses) {
-  moduleStatuses = { ...statuses };
-  localStorage.setItem(MODULE_STATUS_KEY, JSON.stringify(moduleStatuses));
-}
-
-function renderModuleNav() {
-  const sidebar = document.getElementById('moduleSidebar');
-  if (!sidebar) return;
-  sidebar.innerHTML = '';
-
-  workflowModules.forEach((module) => {
-    const status = moduleStatuses[module.id] || 'Not Started';
-    const button = document.createElement('button');
-    button.className = `module-nav-item ${activeModuleId === module.id ? 'active' : ''}`;
-    button.setAttribute('type', 'button');
-    button.innerHTML = `
-      <div class="module-nav-text">
-        <strong>${module.name}</strong>
-        <span class="small">${module.category}</span>
-      </div>
-      <span class="status-pill ${status.toLowerCase().replace(' ', '-') }">${status}</span>
-    `;
-    button.addEventListener('click', () => {
-      activeModuleId = module.id;
-      renderModuleContent();
-      renderModuleNav();
-    });
-    sidebar.appendChild(button);
-  });
-}
-
-function renderModuleContent() {
-  const module = workflowModules.find((item) => item.id === activeModuleId) || workflowModules[0];
-  if (!module) return;
-
-  const category = document.getElementById('moduleCategory');
-  const title = document.getElementById('moduleTitle');
-  const description = document.getElementById('moduleDescription');
-  const linksContainer = document.getElementById('moduleLinks');
-  const embedContainer = document.getElementById('moduleEmbed');
-  const statusSelect = document.getElementById('moduleStatus');
-
-  if (category) category.textContent = module.category;
-  if (title) title.textContent = module.name;
-  if (description) description.textContent = module.description;
-
-  if (linksContainer) {
-    linksContainer.innerHTML = '';
-    module.links.forEach(link => {
-      const anchor = document.createElement('a');
-      anchor.className = 'btn subtle';
-      anchor.textContent = link.label;
-      anchor.href = link.href;
-      anchor.target = '_blank';
-      anchor.rel = 'noopener';
-      linksContainer.appendChild(anchor);
-    });
-  }
-
-  if (embedContainer) {
-    embedContainer.innerHTML = '';
-    const iframe = document.createElement('iframe');
-    iframe.title = module.name;
-    iframe.src = module.iframe;
-    iframe.loading = 'lazy';
-    embedContainer.appendChild(iframe);
-  }
-
-  if (statusSelect) {
-    statusSelect.innerHTML = '';
-    moduleStatusOptions.forEach(option => {
-      const opt = document.createElement('option');
-      opt.value = option;
-      opt.textContent = option;
-      statusSelect.appendChild(opt);
-    });
-    statusSelect.value = moduleStatuses[module.id] || 'Not Started';
-    statusSelect.onchange = (event) => {
-      const nextStatus = event.target.value;
-      saveModuleStatuses({ ...moduleStatuses, [module.id]: nextStatus });
-      renderModuleNav();
-    };
-  }
-}
-
-function getNumeric(value, fallback = 0) {
-  const numberValue = Number(value);
-  return Number.isFinite(numberValue) ? numberValue : fallback;
-}
-
-function buildFeasibilityItems(project) {
-  const duration = getNumeric(project.meta?.durationHours, 0);
-  const sustainment = getNumeric(project.sustainment?.sustainmentHours, 0);
-  const perPersonLoad = getNumeric(project.kitsSummary?.perOperatorLoadKg ?? project.kits?.perOperatorLoadKg, 0);
-  const loadLimit = getNumeric(project.kitsSummary?.perOperatorLimitKg ?? project.kits?.perOperatorLimitKg, 0);
-  const relayCount = getNumeric(project.meshPlan?.relayCount, 0);
-  const criticalLinks = getNumeric(project.meshPlan?.criticalLinks, 0);
-  const meshLinks = Array.isArray(project.mesh_links) ? project.mesh_links.length : 0;
-  const env = Array.isArray(project.environment) && project.environment.length ? project.environment[0] : {};
-  const perOperatorLoads = Array.isArray(project.kitsSummary?.perOperatorLoads) ? project.kitsSummary.perOperatorLoads : [];
-  const avgOperatorLoad = perOperatorLoads.length
-    ? perOperatorLoads.reduce((sum, entry) => sum + getNumeric(entry.weightKg, 0), 0) / perOperatorLoads.length
-    : perPersonLoad;
-
-  const sustainmentGap = sustainment - duration;
-  let sustainmentStatus = 'alert';
-  if (sustainmentGap >= 0) {
-    sustainmentStatus = 'good';
-  } else if (sustainmentGap >= -SUSTAINMENT_WARNING_BUFFER_HOURS) {
-    sustainmentStatus = 'warning';
-  }
-
-  const loadMargin = loadLimit - perPersonLoad;
-  let loadStatus = 'alert';
-  if (loadMargin >= 0) {
-    loadStatus = 'good';
-  } else if (loadMargin >= -LOAD_WARNING_MARGIN_KG) {
-    loadStatus = 'warning';
-  }
-
-  const relayMargin = relayCount - criticalLinks;
-  let relayStatus = 'alert';
-  if (relayMargin >= 0) {
-    relayStatus = 'good';
-  } else if (relayMargin === -1) {
-    relayStatus = 'warning';
-  }
-
-  const rfStatus = meshLinks > 0 ? 'good' : (criticalLinks > 0 ? 'alert' : 'warning');
-  const envStatus = env.altitudeBand && env.temperatureBand ? 'good' : 'warning';
-  const avgLoadStatus = loadLimit && avgOperatorLoad ? (avgOperatorLoad <= loadLimit ? 'good' : 'warning') : 'warning';
-
-  return [
-    {
-      title: 'Mission duration vs sustainment',
-      label: `${sustainment}h sustainment vs ${duration}h duration`,
-      detail: sustainmentGap >= 0 ? 'Sustainment covers the planned duration.' : 'Add sustainment hours or shorten phases.',
-      status: sustainmentStatus
-    },
-    {
-      title: 'Per-person kit weight',
-      label: `${perPersonLoad} kg load vs ${loadLimit} kg limit`,
-      detail: loadMargin >= 0 ? 'Load is within the configured per-person limit.' : 'Trim kit weight or increase allowable load.',
-      status: loadStatus
-    },
-    {
-      title: 'Average load across team',
-      label: perOperatorLoads.length ? `${avgOperatorLoad.toFixed(1)} kg average across ${perOperatorLoads.length} roles` : 'No per-operator loads entered',
-      detail: avgLoadStatus === 'good' ? 'Average load fits within per-person limit.' : 'Balance loads or raise the limit in kitsSummary.',
-      status: avgLoadStatus
-    },
-    {
-      title: 'Relays vs critical links',
-      label: `${relayCount} relays vs ${criticalLinks} critical links`,
-      detail: relayMargin >= 0 ? 'Relays match or exceed critical links.' : 'Add redundancy to avoid single points of failure.',
-      status: relayStatus
-    },
-    {
-      title: 'RF readiness',
-      label: `${meshLinks} mesh links tracked`,
-      detail: meshLinks > 0 ? 'Links present for RF planning.' : 'Add mesh_links for contested or long-range missions.',
-      status: rfStatus
-    },
-    {
-      title: 'Environment coverage',
-      label: env.name ? `${env.name} • ${env.altitudeBand || 'Altitude n/a'} • ${env.temperatureBand || 'Temp n/a'}` : 'Environment not set',
-      detail: env.altitudeBand && env.temperatureBand ? 'Baseline environment set for all modules.' : 'Add altitudeBand and temperatureBand to environment[0].',
-      status: envStatus
-    }
-  ];
-}
-
-function renderFeasibility(project) {
-  const container = document.getElementById('feasibilityItems');
-  if (!container) return;
-  container.innerHTML = '';
-
-  buildFeasibilityItems(project).forEach(item => {
-    const row = document.createElement('div');
-    row.className = `feasibility-item ${item.status}`;
-    row.innerHTML = `
-      <div>
-        <p class="small">${item.title}</p>
-        <strong>${item.label}</strong>
-        <p class="small">${item.detail}</p>
-      </div>
-    `;
-    container.appendChild(row);
-  });
-}
-
-function renderProjectStatus() {
-  const status = document.getElementById('projectStatus');
-  if (!status) return;
-  status.textContent = projectStatusMessage || '';
-  status.hidden = !projectStatusMessage;
-}
-
-function getActiveToolList(project) {
-  const collections = ['nodes', 'platforms', 'mesh_links', 'kits', 'constraints', 'environment', 'mission'];
-  const tools = new Set();
-  collections.forEach((key) => {
-    const value = project[key];
-    if (Array.isArray(value)) {
-      value.forEach((item) => item?.origin_tool && tools.add(item.origin_tool));
-    } else if (value && typeof value === 'object' && value.origin_tool) {
-      tools.add(value.origin_tool);
-    }
-  });
-  if (project.meta?.origin_tool) tools.add(project.meta.origin_tool);
-  return Array.from(tools);
-}
-
-async function renderMissionProjectHealth(projectOverride) {
-  const widget = document.getElementById('missionProjectHealth');
-  if (!widget) return;
-
-  const versionEl = document.getElementById('healthSchemaVersion');
-  const statusEl = document.getElementById('healthValidationStatus');
-  const detailEl = document.getElementById('healthValidationDetail');
-  const tile = document.getElementById('healthValidationTile');
-  const project = projectOverride || MissionProjectStore.loadMissionProject();
-  const version = project?.schemaVersion || MISSION_PROJECT_SCHEMA_VERSION;
-
-  if (versionEl) {
-    versionEl.textContent = version || MISSION_PROJECT_SCHEMA_VERSION;
-  }
-
-  let status = 'good';
-  let headline = 'OK';
-  let detail = 'Required fields present for MissionProject v2.0.0.';
-
-  try {
-    const { valid, errors } = await MissionProjectStore.validateMissionProjectDetailed(project);
-    if (!valid) {
-      status = 'alert';
-      headline = 'Missing required fields';
-      detail = errors.slice(0, 2).join(' • ') || 'Missing required fields.';
-    }
-  } catch (error) {
-    status = 'warning';
-    headline = 'Validation unavailable';
-    detail = 'Schema could not be loaded for validation.';
-  }
-
-  if (statusEl) statusEl.textContent = headline;
-  if (detailEl) detailEl.textContent = detail;
-  if (tile) {
-    tile.classList.remove('good', 'warning', 'alert');
-    tile.classList.add(status);
-  }
-}
-
-function renderSchemaVersion(project) {
-  const badge = document.getElementById('schemaVersionBadge');
-  const detail = document.getElementById('schemaVersionDetail');
-  if (!badge || !detail) return;
-
-  const version = project?.schemaVersion || MISSION_PROJECT_SCHEMA_VERSION;
-  badge.textContent = version;
-  detail.textContent = version === MISSION_PROJECT_SCHEMA_VERSION
-    ? 'Schema matches the hub reference.'
-    : `Loaded payload differs from hub reference (${MISSION_PROJECT_SCHEMA_VERSION}).`;
-}
-
-function renderSchemaWarning(project) {
-  const warning = document.getElementById('schemaWarning');
-  if (!warning) return;
-  const version = project?.schemaVersion;
-  const mismatched = version && version !== MISSION_PROJECT_SCHEMA_VERSION;
-  warning.hidden = !mismatched;
-  if (mismatched) {
-    warning.textContent = `Loaded MissionProject uses schemaVersion ${version}. Hub reference is ${MISSION_PROJECT_SCHEMA_VERSION}. Data will be preserved.`;
-  } else {
-    warning.textContent = '';
-  }
-}
-
-function renderProjectSummary(project) {
-  const list = document.getElementById('projectSummaryList');
-  if (!list) return;
-  list.innerHTML = '';
-
-  const env = Array.isArray(project.environment) && project.environment.length ? project.environment[0] : {};
-  const summaryItems = [
-    { label: 'Duration', value: project.meta?.durationHours ? `${project.meta.durationHours}h` : 'Not set' },
-    { label: 'Team size', value: project.meta?.team?.size ? `${project.meta.team.size} personnel` : 'Not set' },
-    { label: 'Altitude band', value: env.altitudeBand || 'Not set' },
-    { label: 'Temperature band', value: env.temperatureBand || 'Not set' },
-    { label: 'Nodes', value: Array.isArray(project.nodes) ? project.nodes.length : 0 },
-    { label: 'Platforms', value: Array.isArray(project.platforms) ? project.platforms.length : 0 },
-    { label: 'Mesh links', value: Array.isArray(project.mesh_links) ? project.mesh_links.length : 0 },
-    { label: 'Kits', value: Array.isArray(project.kits) ? project.kits.length : 0 },
-    { label: 'Active tools', value: getActiveToolList(project).join(', ') || 'Not tagged' }
-  ];
-
-  summaryItems.forEach((item) => {
-    const row = document.createElement('li');
-    row.innerHTML = `<span>${item.label}</span><strong>${item.value}</strong>`;
-    list.appendChild(row);
-  });
-}
-
-function renderEditorErrors() {
-  const errorBox = document.getElementById('projectJsonErrors');
-  if (!errorBox) return;
-  if (!editorErrors.length) {
-    errorBox.textContent = 'JSON matches required fields.';
-    errorBox.className = 'editor-status success';
-    return;
-  }
-  errorBox.className = 'editor-status alert';
-  errorBox.innerHTML = editorErrors.map((err) => `<li>${err}</li>`).join('');
-}
-
-function renderSchemaValidationResults({ valid, errors, version }) {
-  const resultEl = document.getElementById('schemaValidationResult');
-  const errorList = document.getElementById('schemaValidationErrors');
-  if (!resultEl || !errorList) return;
-
-  errorList.innerHTML = '';
-  if (valid) {
-    resultEl.className = 'validation-callout success';
-    resultEl.textContent = `Valid MissionProject for schema v${version}`;
-  } else {
-    resultEl.className = 'validation-callout alert';
-    resultEl.textContent = 'MissionProject failed schema validation';
-    errors.forEach((err) => {
-      const item = document.createElement('li');
-      item.textContent = err;
-      errorList.appendChild(item);
-    });
-  }
-}
-
-async function handleSchemaValidation(applyToWorkspace = false) {
-  const textarea = document.getElementById('schemaValidatorInput');
-  if (!textarea) return;
-  try {
-    const parsed = JSON.parse(textarea.value || '{}');
-    const { valid, errors } = await MissionProjectStore.validateMissionProjectDetailed(parsed);
-    const schema = await MissionProjectStore.fetchMissionProjectSchema();
-    const description = schema?.description || '';
-    const versionMatch = description.match(/v(\d+\.\d+\.\d+)/i);
-    const version = versionMatch ? versionMatch[1] : (schema?.properties?.schemaVersion?.default || MISSION_PROJECT_SCHEMA_VERSION);
-    renderSchemaValidationResults({ valid, errors, version });
-
-    if (applyToWorkspace && valid) {
-      const saved = MissionProjectStore.importMissionProjectFromText(textarea.value);
-      projectStatusMessage = saved.meta?.name ? `Imported project: ${saved.meta.name}` : 'Project applied from validator.';
-      projectLoadSource = 'Schema validator';
-      setProjectAlert('JSON applied to MissionProject store.', 'success');
-      hydrateProjectForm('Schema validator');
-      renderMissionProjectStatusPanel(saved);
-    } else if (applyToWorkspace && !valid) {
-      setProjectAlert('Fix schema errors before applying to the workspace.', 'alert');
-    }
-  } catch (error) {
-    renderSchemaValidationResults({ valid: false, errors: [error.message], version: MISSION_PROJECT_SCHEMA_VERSION });
-  }
-}
-
-function applyWorkflowGuard() {
-  const guard = document.getElementById('workflowGuard');
-  const overlay = document.getElementById('workflowAccessOverlay');
-  const banner = document.getElementById('workflowAccessBanner');
-  const dashboard = document.querySelector('.workflow-dashboard');
-  const lockedNotice = document.getElementById('plannerLockedNotice');
-  const authorized = hasDemoAccess();
-
-  if (guard) {
-    guard.classList.toggle('locked', !authorized);
-    guard.setAttribute('aria-busy', (!authorized).toString());
-  }
-  if (overlay) {
-    overlay.style.display = authorized ? 'none' : 'flex';
-  }
-  if (dashboard) {
-    dashboard.classList.toggle('blurred', !authorized);
-    dashboard.setAttribute('aria-hidden', (!authorized).toString());
-  }
-  if (banner) {
-    banner.hidden = !authorized;
-    if (authorized) {
-      banner.textContent = 'Demo access granted — embedded planners unlocked.';
-    }
-  }
-  if (lockedNotice) {
-    lockedNotice.hidden = authorized;
-  }
-}
-
-window.applyWorkflowGuard = applyWorkflowGuard;
-
-function renderMissionProjectStatusPanel(projectOverride) {
-  const panel = document.getElementById('missionProjectStatusPanel');
-  if (!panel) return;
-
-  const project = projectOverride || MissionProjectStore.loadMissionProject();
-  const hasStoredProject = MissionProjectStore.hasMissionProject();
-  const env = Array.isArray(project.environment) && project.environment.length ? project.environment[0] : {};
-  const lastUpdated = MissionProjectStore.getLastUpdated();
-  const displayLoaded = hasStoredProject && projectLoadSource && projectLoadSource !== 'Starter template';
-
-  const nameEl = document.getElementById('statusProjectName');
-  const metaEl = document.getElementById('statusProjectMeta');
-  const sourceEl = document.getElementById('statusProjectSource');
-  const schemaRef = document.getElementById('statusSchemaVersion');
-  const updatedRef = document.getElementById('statusLastUpdated');
-  const statusActions = document.getElementById('statusActions');
-  const importBtn = document.getElementById('homeImportProject');
-  const clearBtn = document.getElementById('homeClearProject');
-
-  const name = displayLoaded ? (project.meta?.name || 'Mission project') : 'No project loaded';
-  const duration = project.meta?.durationHours ? `${project.meta.durationHours}h` : 'Duration not set';
-  const envLabel = env?.name || env?.altitudeBand || 'Environment not set';
-  const sourceLabel = displayLoaded ? projectLoadSource : 'Not loaded';
-  const updatedLabel = displayLoaded ? formatTimestamp(lastUpdated) : 'Not set';
-
-  if (nameEl) nameEl.textContent = name;
-  if (metaEl) metaEl.textContent = displayLoaded
-    ? `${duration} • ${envLabel}`
-    : 'No MissionProject loaded. Use the demo payload to start.';
-  if (sourceEl) sourceEl.textContent = sourceLabel;
-  if (schemaRef) schemaRef.textContent = project.schemaVersion || MISSION_PROJECT_SCHEMA_VERSION;
-  if (updatedRef) updatedRef.textContent = updatedLabel;
-  if (statusActions) {
-    const lockToDemo = !displayLoaded;
-    if (importBtn) importBtn.hidden = lockToDemo;
-    if (clearBtn) clearBtn.hidden = lockToDemo;
-  }
-  renderSchemaVersion(project);
-  renderSchemaWarning(project);
-  renderProjectSummary(project);
-  renderMissionProjectHealth(project);
-}
-
-function setProjectAlert(message, tone = 'info') {
-  const alertBox = document.getElementById('projectAlert');
-  if (!alertBox) return;
-  alertBox.textContent = message || '';
-  alertBox.className = `project-alert ${tone}`;
-  alertBox.hidden = !message;
-}
-
-function loadProjectJsonEditor(project) {
-  const editor = document.getElementById('projectJsonEditor');
-  if (!editor) return;
-  editor.value = JSON.stringify(project, null, 2);
-}
-
-async function validateProjectJsonEditor(applyAfterValidate = false) {
-  const editor = document.getElementById('projectJsonEditor');
-  if (!editor) return;
-  try {
-    const parsed = JSON.parse(editor.value || '{}');
-    const { valid, errors } = await MissionProjectStore.validateMissionProjectDetailed(parsed);
-    editorErrors = errors || [];
-    if (applyAfterValidate && valid) {
-      const saved = MissionProjectStore.importMissionProjectFromText(editor.value);
-      projectStatusMessage = saved.meta?.name ? `Imported project: ${saved.meta.name}` : 'Project applied from editor.';
-      projectLoadSource = 'JSON editor';
-      hydrateProjectForm('JSON editor');
-      renderMissionProjectStatusPanel(saved);
-      setProjectAlert('JSON applied to MissionProject store.', 'success');
-    } else if (applyAfterValidate && !valid) {
-      setProjectAlert('Fix schema errors before applying to the workspace.', 'alert');
-    } else if (valid) {
-      setProjectAlert('JSON looks valid against schema reference.', 'success');
-    } else {
-      setProjectAlert('Validation found schema issues. See error list below.', 'alert');
-    }
-  } catch (error) {
-    editorErrors = [error.message];
-    setProjectAlert('Invalid JSON. Please fix syntax before applying.', 'alert');
-  }
-  renderEditorErrors();
-}
-
-function hydrateProjectForm(sourceLabel) {
-  const hasStoredProject = MissionProjectStore.hasMissionProject();
-  const baseProject = hasStoredProject ? MissionProjectStore.loadMissionProject() : MissionProjectStore.createEmptyMissionProject();
-  setProjectAlert('', 'info');
-  const project = MissionProjectStore.saveMissionProject(baseProject);
-
-  if (sourceLabel) {
-    projectLoadSource = sourceLabel;
-  } else if (!projectLoadSource) {
-    projectLoadSource = hasStoredProject ? 'Local storage' : 'Starter template';
-  }
-
-  if (!projectStatusMessage && project.meta?.name) {
-    projectStatusMessage = `Active project: ${project.meta.name}`;
-  }
-  const env = Array.isArray(project.environment) ? project.environment[0] : project.meta?.environment;
-  document.getElementById('missionName').value = project.meta?.name || '';
-  ensureOption(document.getElementById('environmentBand'), env?.band || env?.environmentBand);
-  document.getElementById('environmentBand').value = env?.band || env?.environmentBand || '';
-  ensureOption(document.getElementById('ewLevel'), project.meshPlan?.ew_profile);
-  document.getElementById('ewLevel').value = project.meshPlan?.ew_profile || '';
-  ensureOption(document.getElementById('missionType'), project.meta?.missionType);
-  document.getElementById('missionType').value = project.meta?.missionType || '';
-  document.getElementById('altitudeBand').value = env?.altitudeBand || '';
-  document.getElementById('temperatureBand').value = env?.temperatureBand || '';
-  document.getElementById('durationHours').value = project.meta?.durationHours || 24;
-  document.getElementById('inventoryReference').value = project.meta?.inventoryReference || '';
-  document.getElementById('sustainmentHours').value = project.sustainment?.sustainmentHours ?? '';
-  document.getElementById('perPersonLoad').value = project.kitsSummary?.perOperatorLoadKg ?? project.kits?.perOperatorLoadKg ?? '';
-  document.getElementById('perPersonLimit').value = project.kitsSummary?.perOperatorLimitKg ?? project.kits?.perOperatorLimitKg ?? '';
-  document.getElementById('relayCount').value = project.meshPlan?.relayCount ?? '';
-  document.getElementById('criticalLinks').value = project.meshPlan?.criticalLinks ?? '';
-
-  renderFeasibility(project);
-  renderProjectStatus();
-  renderMissionProjectStatusPanel(project);
-  loadProjectJsonEditor(project);
-  editorErrors = [];
-  renderEditorErrors();
-}
-
-function syncProjectFromForm() {
-  const project = MissionProjectStore.loadMissionProject();
-  project.meta.name = document.getElementById('missionName').value;
-  const environmentBand = document.getElementById('environmentBand').value;
-  const altitudeBand = document.getElementById('altitudeBand').value;
-  const temperatureBand = document.getElementById('temperatureBand').value;
-  const ewProfile = document.getElementById('ewLevel').value;
-  const missionType = document.getElementById('missionType').value;
-  const env = Array.isArray(project.environment) && project.environment.length ? project.environment[0] : {};
-  project.environment[0] = {
-    ...env,
-    id: env.id || 'env-main',
-    name: env.name || 'Baseline AO',
-    band: environmentBand || env.band || env.environmentBand,
-    altitudeBand,
-    temperatureBand,
-    origin_tool: env.origin_tool || 'hub'
-  };
-  project.meshPlan.ew_profile = ewProfile || project.meshPlan.ew_profile;
-  project.meta.missionType = missionType || project.meta.missionType;
-  project.meta.durationHours = getNumeric(document.getElementById('durationHours').value, project.meta.durationHours);
-  project.meta.inventoryReference = document.getElementById('inventoryReference').value;
-  project.sustainment.sustainmentHours = getNumeric(document.getElementById('sustainmentHours').value, project.sustainment.sustainmentHours);
-  project.kitsSummary = {
-    ...(project.kitsSummary || {}),
-    perOperatorLoadKg: getNumeric(document.getElementById('perPersonLoad').value, project.kitsSummary?.perOperatorLoadKg),
-    perOperatorLimitKg: getNumeric(document.getElementById('perPersonLimit').value, project.kitsSummary?.perOperatorLimitKg)
-  };
-  project.meshPlan.relayCount = getNumeric(document.getElementById('relayCount').value, project.meshPlan.relayCount);
-  project.meshPlan.criticalLinks = getNumeric(document.getElementById('criticalLinks').value, project.meshPlan.criticalLinks);
-
-  const saved = MissionProjectStore.saveMissionProject(project);
-  renderFeasibility(saved);
-  projectStatusMessage = saved.meta?.name ? `Active project: ${saved.meta.name}` : '';
-  projectLoadSource = projectLoadSource || 'Local storage';
-  renderProjectStatus();
-  renderMissionProjectStatusPanel(saved);
-}
-
-function bindProjectForm() {
-  const form = document.getElementById('projectMetaForm');
-  if (!form) return;
-  form.addEventListener('input', syncProjectFromForm);
-  form.addEventListener('change', syncProjectFromForm);
-}
-
-function attachImportHandlers(button, fileInput, sourceLabel = 'Imported JSON') {
-  button?.addEventListener('click', (event) => {
-    event.preventDefault();
-    fileInput?.click();
-  });
-
-  fileInput?.addEventListener('change', (event) => {
-    const [file] = event.target.files || [];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = async (loadEvent) => {
-      try {
-        const text = loadEvent.target.result;
-        const parsed = JSON.parse(text || '{}');
-        const { valid, errors } = await MissionProjectStore.validateMissionProjectDetailed(parsed);
-        if (!valid) {
-          setProjectAlert(`Unable to import: ${errors.join('; ')}`, 'alert');
-          editorErrors = errors || [];
-          renderEditorErrors();
-          return;
-        }
-        const saved = MissionProjectStore.importMissionProjectFromText(text);
-        projectStatusMessage = saved.meta?.name ? `Imported project: ${saved.meta.name}` : 'Imported MissionProject payload.';
-        projectLoadSource = sourceLabel;
-        setProjectAlert('MissionProject imported successfully.', 'success');
-        hydrateProjectForm(sourceLabel);
-      } catch (error) {
-        console.error('Unable to import project JSON', error);
-        setProjectAlert('Unable to import project JSON. Please verify the MissionProject schema.', 'alert');
-      } finally {
-        if (fileInput) fileInput.value = '';
-        renderProjectStatus();
-        renderMissionProjectStatusPanel();
-      }
-    };
-    reader.readAsText(file);
-  });
-}
-
-async function loadArchetypeProject(archetype, button) {
-  const defaultLabel = button?.textContent;
-  if (button) {
-    button.disabled = true;
-    button.textContent = 'Loading archetype…';
-  }
-
-  try {
-    const response = await fetch(archetype.path);
-    if (!response.ok) {
-      throw new Error('Unable to fetch archetype JSON');
-    }
-    const payload = await response.json();
-    const { valid, errors } = await MissionProjectStore.validateMissionProjectDetailed(payload);
-    if (!valid) {
-      setProjectAlert(`Archetype failed validation: ${errors.join('; ')}`, 'alert');
-      editorErrors = errors || [];
-      renderEditorErrors();
-      return;
-    }
-    const saved = MissionProjectStore.saveMissionProject(payload);
-    projectStatusMessage = saved.meta?.name ? `${saved.meta.name} loaded.` : `${archetype.label} loaded.`;
-    projectLoadSource = archetype.label;
-    setProjectAlert('Archetype applied to workspace.', 'success');
-    hydrateProjectForm(archetype.label);
-    renderMissionProjectHealth(saved);
-  } catch (error) {
-    console.error('Unable to load archetype', error);
-    setProjectAlert('Unable to load the archetype project. Please try again.', 'alert');
-  } finally {
-    if (button) {
-      button.disabled = false;
-      button.textContent = defaultLabel || 'Load archetype';
-    }
-    renderProjectStatus();
-    renderMissionProjectStatusPanel();
-  }
-}
-
-async function loadWhitefrostDemo(button) {
-  const defaultLabel = button?.dataset.defaultLabel || 'Run the WHITEFROST demo';
-  if (button) {
-    button.disabled = true;
-    button.textContent = 'Preparing WHITEFROST…';
-  }
-
-  try {
-    const archetype = missionArchetypes.find((item) => item.id === 'whitefrost');
-    if (archetype) {
-      await loadArchetypeProject(archetype, button);
-      return;
-    }
-    setProjectAlert('WHITEFROST preset not found.', 'alert');
-  } catch (error) {
-    console.error(error);
-    setProjectAlert('Unable to stage WHITEFROST demo. Please try again.', 'alert');
-  } finally {
-    if (button) {
-      button.disabled = false;
-      button.textContent = defaultLabel;
-    }
-    renderProjectStatus();
-    renderMissionProjectStatusPanel();
-  }
-}
-
-async function loadDemoProject(button) {
-  const defaultLabel = button?.dataset.defaultLabel || 'Load demo project';
-  if (button) {
-    button.disabled = true;
-    button.textContent = 'Loading demo…';
-  }
-
-  try {
-    const response = await fetch(DEMO_PROJECT_PATH);
-    if (!response.ok) {
-      throw new Error('Unable to fetch demo project');
-    }
-    const payload = await response.json();
-    const { valid, errors } = await MissionProjectStore.validateMissionProjectDetailed(payload);
-    if (!valid) {
-      throw new Error(`Invalid demo project payload: ${errors.join('; ')}`);
-    }
-    const saved = MissionProjectStore.saveMissionProject(payload);
-    projectStatusMessage = saved.meta?.name ? `${saved.meta.name} loaded.` : 'Demo project loaded.';
-    projectLoadSource = 'Demo project';
-    setProjectAlert('Demo project loaded. Exports now mirror the shared schema.', 'success');
-    hydrateProjectForm('Demo project');
-  } catch (error) {
-    console.error(error);
-    setProjectAlert('Unable to load the demo project. Please try again.', 'alert');
-  } finally {
-    if (button) {
-      button.disabled = false;
-      button.textContent = defaultLabel;
-    }
-    renderProjectStatus();
-    renderMissionProjectStatusPanel();
-  }
-}
-
-function bindProjectActions() {
-  const exportBtn = document.getElementById('exportProject');
-  const importBtn = document.getElementById('importProject');
-  const importFile = document.getElementById('importProjectFile');
-  const demoBtn = document.getElementById('loadDemoProject');
-  const whitefrostBtn = document.getElementById('runWhitefrostDemo');
-  const exportGeoBtn = document.getElementById('exportGeo');
-  const exportCoTBtn = document.getElementById('exportCoT');
-  const validateBtn = document.getElementById('validateProjectJson');
-  const applyBtn = document.getElementById('applyProjectJson');
-
-  exportBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    MissionProjectStore.exportMissionProject();
-    setProjectAlert('MissionProject exported.', 'info');
-  });
-
-  exportGeoBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    MissionProjectStore.exportGeoJSON();
-    setProjectAlert('GeoJSON export ready for TAK/overlays.', 'info');
-  });
-
-  exportCoTBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    MissionProjectStore.exportCoTStub();
-    setProjectAlert('CoT stub export saved.', 'info');
-  });
-
-  attachImportHandlers(importBtn, importFile, 'Imported JSON');
-
-  demoBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    loadDemoProject(demoBtn);
-  });
-
-  whitefrostBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    loadWhitefrostDemo(whitefrostBtn);
-  });
-
-  validateBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    validateProjectJsonEditor(false);
-  });
-
-  applyBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    validateProjectJsonEditor(true);
-  });
-}
-
-function bindSchemaValidator() {
-  const validateBtn = document.getElementById('schemaValidateBtn');
-  const applyBtn = document.getElementById('schemaApplyBtn');
-
-  validateBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    handleSchemaValidation(false);
-  });
-
-  applyBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    handleSchemaValidation(true);
-  });
-}
-
-function bindStatusPanelActions() {
-  const loadBtn = document.getElementById('homeLoadDemo');
-  const importBtn = document.getElementById('homeImportProject');
-  const importFile = document.getElementById('homeImportProjectFile');
-  const clearBtn = document.getElementById('homeClearProject');
-
-  attachImportHandlers(importBtn, importFile, 'Imported JSON');
-
-  loadBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    loadDemoProject(loadBtn);
-  });
-
-  clearBtn?.addEventListener('click', (event) => {
-    event.preventDefault();
-    MissionProjectStore.clearMissionProject();
-    projectStatusMessage = '';
-    projectLoadSource = 'Starter template';
-    setProjectAlert('', 'info');
-    hydrateProjectForm('Starter template');
-    renderMissionProjectStatusPanel();
-  });
-}
-
-async function initWorkflowDashboard() {
-  moduleStatuses = loadModuleStatuses();
-  renderModuleNav();
-  renderModuleContent();
-  await applyTaxonomyToForms();
-  hydrateProjectForm();
-  bindProjectForm();
-  bindProjectActions();
-}
+// ============================================================================
+// THEME TOGGLE
+// ============================================================================
 
 function initThemeToggle() {
   const toggle = document.getElementById('themeToggle');
-  const saved = localStorage.getItem('ceradon-theme');
-  if (saved) {
-    document.documentElement.setAttribute('data-theme', saved);
-  }
-  toggle.textContent = document.documentElement.getAttribute('data-theme') === 'light' ? '☀️' : '🌙';
+  const html = document.documentElement;
+
+  const savedTheme = localStorage.getItem('ceradon_theme') || 'dark';
+  html.setAttribute('data-theme', savedTheme);
+  toggle.textContent = savedTheme === 'dark' ? '🌙' : '☀️';
 
   toggle.addEventListener('click', () => {
-    const current = document.documentElement.getAttribute('data-theme');
-    const next = current === 'light' ? 'dark' : 'light';
-    document.documentElement.setAttribute('data-theme', next);
-    localStorage.setItem('ceradon-theme', next);
-    toggle.textContent = next === 'light' ? '☀️' : '🌙';
+    const current = html.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
+    toggle.textContent = next === 'dark' ? '🌙' : '☀️';
+    localStorage.setItem('ceradon_theme', next);
   });
 }
 
-async function initApp() {
-  buildTools();
-  buildDemos();
-  renderMissionArchetypes();
-  await initWorkflowDashboard();
-  bindStatusPanelActions();
-  initThemeToggle();
-  renderVersionBadges();
-  renderChangeLog();
-  bindSchemaValidator();
-  applyWorkflowGuard();
-  handleHashChange();
-  await renderSchemaVersionMetadata();
-  window.addEventListener('hashchange', handleHashChange);
-  window.addEventListener('ceradon-demo-authorized', applyWorkflowGuard);
-  window.addEventListener('storage', (event) => {
-    if (event.key === DEMO_ACCESS_KEY) {
-      applyWorkflowGuard();
-    }
+// ============================================================================
+// VERSION BADGES
+// ============================================================================
+
+function initVersionBadges() {
+  document.querySelectorAll('[data-app-version]').forEach(el => {
+    el.textContent = APP_VERSION;
+  });
+  document.querySelectorAll('[data-schema-version]').forEach(el => {
+    el.textContent = SCHEMA_VERSION;
   });
 }
+
+// ============================================================================
+// HOME PAGE
+// ============================================================================
+
+function initHomePage() {
+  // Load sample mission button
+  const loadSampleBtn = document.getElementById('loadSampleMission');
+  if (loadSampleBtn) {
+    loadSampleBtn.addEventListener('click', loadSampleMission);
+  }
+
+  // Project status buttons
+  const homeLoadDemo = document.getElementById('homeLoadDemo');
+  if (homeLoadDemo) {
+    homeLoadDemo.addEventListener('click', loadSampleMission);
+  }
+
+  const homeImportProject = document.getElementById('homeImportProject');
+  const homeImportProjectFile = document.getElementById('homeImportProjectFile');
+  if (homeImportProject && homeImportProjectFile) {
+    homeImportProject.addEventListener('click', () => homeImportProjectFile.click());
+    homeImportProjectFile.addEventListener('change', handleProjectImport);
+  }
+
+  const homeClearProject = document.getElementById('homeClearProject');
+  if (homeClearProject) {
+    homeClearProject.addEventListener('click', clearProject);
+  }
+
+  // Update project status display
+  updateProjectStatus();
+}
+
+function loadSampleMission() {
+  fetch('data/demo_mission_project.json')
+    .then(response => response.json())
+    .then(data => {
+      if (typeof MissionProjectStore !== 'undefined') {
+        MissionProjectStore.saveMissionProject(data);
+        updateProjectStatus();
+        alert('Sample mission loaded successfully!');
+      }
+    })
+    .catch(error => {
+      console.error('Failed to load sample mission:', error);
+      alert('Failed to load sample mission. Check console for details.');
+    });
+}
+
+function handleProjectImport(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    try {
+      const data = JSON.parse(e.target.result);
+      if (typeof MissionProjectStore !== 'undefined') {
+        MissionProjectStore.saveMissionProject(data);
+        updateProjectStatus();
+        alert('Project imported successfully!');
+      }
+    } catch (error) {
+      console.error('Failed to import project:', error);
+      alert('Failed to import project. Invalid JSON file.');
+    }
+  };
+  reader.readAsText(file);
+}
+
+function clearProject() {
+  if (confirm('Clear current project? This will remove all local data.')) {
+    localStorage.removeItem('ceradon_mission_project');
+    updateProjectStatus();
+  }
+}
+
+function updateProjectStatus() {
+  const statusName = document.getElementById('statusProjectName');
+  const statusMeta = document.getElementById('statusProjectMeta');
+  const statusSource = document.getElementById('statusProjectSource');
+  const statusUpdated = document.getElementById('statusLastUpdated');
+
+  if (typeof MissionProjectStore !== 'undefined') {
+    const project = MissionProjectStore.loadMissionProject();
+
+    if (statusName) {
+      statusName.textContent = project.meta?.name || 'Unnamed Project';
+    }
+    if (statusMeta) {
+      const platforms = project.platforms?.length || 0;
+      const phases = project.mission?.phases?.length || 0;
+      statusMeta.textContent = `${platforms} platform(s), ${phases} phase(s)`;
+    }
+    if (statusSource) {
+      statusSource.textContent = project.meta?.inventory_catalog || 'Not specified';
+    }
+    if (statusUpdated) {
+      statusUpdated.textContent = project.meta?.last_updated ? new Date(project.meta.last_updated).toLocaleString() : 'Not set';
+    }
+  }
+}
+
+// ============================================================================
+// PARTS LIBRARY
+// ============================================================================
+
+let partsLibraryInitialized = false;
+
+function initPartsLibrary() {
+  if (partsLibraryInitialized) return;
+  partsLibraryInitialized = true;
+
+  console.log('Initializing Parts Library...');
+
+  // Initialize IndexedDB
+  if (typeof PartsLibrary !== 'undefined') {
+    PartsLibrary.initDB().then(() => {
+      console.log('Parts Library DB initialized');
+      loadPartsLibraryUI();
+    }).catch(error => {
+      console.error('Failed to initialize Parts Library DB:', error);
+    });
+  }
+
+  // Wire up buttons
+  const importCSV = document.getElementById('importCSV');
+  const csvFileInput = document.getElementById('csvFileInput');
+  if (importCSV && csvFileInput) {
+    importCSV.addEventListener('click', () => csvFileInput.click());
+    csvFileInput.addEventListener('change', handleCSVImport);
+  }
+
+  const loadSampleParts = document.getElementById('loadSampleParts');
+  if (loadSampleParts) {
+    loadSampleParts.addEventListener('click', loadSamplePartsLibrary);
+  }
+
+  const exportPartsJSON = document.getElementById('exportPartsJSON');
+  if (exportPartsJSON) {
+    exportPartsJSON.addEventListener('click', exportPartsLibrary);
+  }
+
+  // Wire up search and filters
+  const partsSearch = document.getElementById('partsSearch');
+  if (partsSearch) {
+    partsSearch.addEventListener('input', filterParts);
+  }
+
+  const partsCategoryFilter = document.getElementById('partsCategoryFilter');
+  if (partsCategoryFilter) {
+    partsCategoryFilter.addEventListener('change', filterParts);
+  }
+}
+
+function handleCSVImport(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = (e) => {
+    const csvText = e.target.result;
+
+    if (typeof CSVImporter !== 'undefined') {
+      try {
+        const parts = CSVImporter.parseCSV(csvText);
+        console.log(`Parsed ${parts.length} parts from CSV`);
+
+        // Import into PartsLibrary
+        if (typeof PartsLibrary !== 'undefined') {
+          Promise.all(parts.map(part => PartsLibrary.addPart(part.category || 'accessories', part)))
+            .then(() => {
+              alert(`Imported ${parts.length} parts successfully!`);
+              loadPartsLibraryUI();
+            })
+            .catch(error => {
+              console.error('Failed to import parts:', error);
+              alert('Failed to import some parts. Check console for details.');
+            });
+        }
+      } catch (error) {
+        console.error('Failed to parse CSV:', error);
+        alert('Failed to parse CSV file. Check format and try again.');
+      }
+    }
+  };
+  reader.readAsText(file);
+}
+
+function loadSamplePartsLibrary() {
+  fetch('data/sample_parts_library.json')
+    .then(response => response.json())
+    .then(data => {
+      if (typeof PartsLibrary !== 'undefined') {
+        PartsLibrary.importLibrary(data).then(() => {
+          alert('Sample parts library loaded successfully!');
+          loadPartsLibraryUI();
+        }).catch(error => {
+          console.error('Failed to load sample library:', error);
+          alert('Failed to load sample library. Check console for details.');
+        });
+      }
+    })
+    .catch(error => {
+      console.error('Failed to fetch sample library:', error);
+      alert('Failed to fetch sample library. Check console for details.');
+    });
+}
+
+function exportPartsLibrary() {
+  if (typeof PartsLibrary !== 'undefined') {
+    PartsLibrary.exportLibrary().then(library => {
+      const json = JSON.stringify(library, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'parts_library.json';
+      a.click();
+      URL.revokeObjectURL(url);
+    }).catch(error => {
+      console.error('Failed to export library:', error);
+      alert('Failed to export library. Check console for details.');
+    });
+  }
+}
+
+async function loadPartsLibraryUI() {
+  if (typeof PartsLibrary === 'undefined') return;
+
+  const grid = document.getElementById('partsGrid');
+  if (!grid) return;
+
+  try {
+    const library = await PartsLibrary.exportLibrary();
+    const allParts = [];
+
+    // Flatten all categories into one array
+    Object.entries(library).forEach(([category, parts]) => {
+      if (Array.isArray(parts)) {
+        parts.forEach(part => {
+          allParts.push({ ...part, category });
+        });
+      }
+    });
+
+    if (allParts.length === 0) {
+      grid.innerHTML = '<p class="small muted">No parts in library. Import CSV or load sample catalog.</p>';
+      updatePartsStatus(`No parts loaded`);
+      return;
+    }
+
+    grid.innerHTML = allParts.map(part => `
+      <div class="part-card">
+        <strong>${part.name || part.model || 'Unnamed Part'}</strong>
+        <p class="small muted">${part.category || 'Unknown'}</p>
+        <p class="small">${part.manufacturer || ''} ${part.model || ''}</p>
+        <div class="part-specs">
+          ${part.weight_g ? `<span>${part.weight_g}g</span>` : ''}
+          ${part.cost_usd ? `<span>$${part.cost_usd}</span>` : ''}
+        </div>
+      </div>
+    `).join('');
+
+    updatePartsStatus(`${allParts.length} parts loaded`);
+  } catch (error) {
+    console.error('Failed to load parts UI:', error);
+    grid.innerHTML = '<p class="small muted">Error loading parts. Check console for details.</p>';
+  }
+}
+
+function filterParts() {
+  const searchTerm = document.getElementById('partsSearch')?.value.toLowerCase() || '';
+  const category = document.getElementById('partsCategoryFilter')?.value || 'all';
+
+  const cards = document.querySelectorAll('.part-card');
+  cards.forEach(card => {
+    const text = card.textContent.toLowerCase();
+    const matchesSearch = !searchTerm || text.includes(searchTerm);
+    const matchesCategory = category === 'all' || card.querySelector('.small.muted')?.textContent === category;
+
+    card.style.display = matchesSearch && matchesCategory ? 'block' : 'none';
+  });
+}
+
+function updatePartsStatus(message) {
+  const status = document.getElementById('partsLibraryStatus');
+  if (status) {
+    status.textContent = message;
+  }
+}
+
+// ============================================================================
+// PLATFORM DESIGNER
+// ============================================================================
+
+let platformDesignerInitialized = false;
+
+function initPlatformDesigner() {
+  if (platformDesignerInitialized) return;
+  platformDesignerInitialized = true;
+
+  console.log('Initializing Platform Designer...');
+
+  // Wire up validation button
+  const validateBtn = document.getElementById('validatePlatform');
+  if (validateBtn) {
+    validateBtn.addEventListener('click', validatePlatform);
+  }
+
+  const savePlatformBtn = document.getElementById('savePlatform');
+  if (savePlatformBtn) {
+    savePlatformBtn.addEventListener('click', savePlatform);
+  }
+
+  // TODO: Load component selectors from Parts Library
+  loadComponentSelectors();
+}
+
+function loadComponentSelectors() {
+  const container = document.getElementById('componentSelection');
+  if (!container) return;
+
+  container.innerHTML = `
+    <p class="small muted">Component selection will be populated from Parts Library</p>
+    <p class="small">Navigate to Parts Library to load components first.</p>
+  `;
+}
+
+function validatePlatform() {
+  const resultsDiv = document.getElementById('validationResults');
+  if (!resultsDiv) return;
+
+  resultsDiv.innerHTML = `
+    <p class="small muted">Platform validation will check:</p>
+    <ul class="bullet-list">
+      <li>Thrust-to-weight ratio</li>
+      <li>Flight time estimates</li>
+      <li>Environmental derating (altitude, temperature)</li>
+      <li>Component compatibility</li>
+    </ul>
+    <p class="small">Build platform designer UI to enable validation.</p>
+  `;
+}
+
+function savePlatform() {
+  alert('Platform save functionality will be implemented');
+}
+
+// ============================================================================
+// MISSION PLANNER
+// ============================================================================
+
+let missionPlannerInitialized = false;
+
+function initMissionPlanner() {
+  if (missionPlannerInitialized) return;
+  missionPlannerInitialized = true;
+
+  console.log('Initializing Mission Planner...');
+
+  const addPhaseBtn = document.getElementById('addPhase');
+  if (addPhaseBtn) {
+    addPhaseBtn.addEventListener('click', addPhase);
+  }
+
+  const calculateBtn = document.getElementById('calculateLogistics');
+  if (calculateBtn) {
+    calculateBtn.addEventListener('click', calculateLogistics);
+  }
+
+  const downloadBtn = document.getElementById('downloadPackingLists');
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', downloadPackingLists);
+  }
+}
+
+function addPhase() {
+  alert('Add phase functionality will be implemented');
+}
+
+function calculateLogistics() {
+  const resultsDiv = document.getElementById('logisticsResults');
+  if (!resultsDiv) return;
+
+  resultsDiv.innerHTML = `
+    <p class="small muted">Logistics calculation will compute:</p>
+    <ul class="bullet-list">
+      <li>Battery swap schedules</li>
+      <li>Per-operator packing lists</li>
+      <li>Weight distribution across team</li>
+      <li>Mission feasibility checks</li>
+    </ul>
+  `;
+}
+
+function downloadPackingLists() {
+  alert('Packing list download will be implemented');
+}
+
+// ============================================================================
+// COMMS VALIDATOR
+// ============================================================================
+
+let commsValidatorInitialized = false;
+
+function initCommsValidator() {
+  if (commsValidatorInitialized) return;
+  commsValidatorInitialized = true;
+
+  console.log('Initializing Comms Validator...');
+
+  const addNodeBtn = document.getElementById('addNode');
+  if (addNodeBtn) {
+    addNodeBtn.addEventListener('click', addNode);
+  }
+
+  const analyzeBtn = document.getElementById('analyzeLinks');
+  if (analyzeBtn) {
+    analyzeBtn.addEventListener('click', analyzeLinks);
+  }
+
+  const downloadBtn = document.getElementById('downloadCommsReport');
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', downloadCommsReport);
+  }
+}
+
+function addNode() {
+  alert('Add node functionality will be implemented');
+}
+
+function analyzeLinks() {
+  const resultsDiv = document.getElementById('linkAnalysisResults');
+  if (!resultsDiv) return;
+
+  resultsDiv.innerHTML = `
+    <p class="small muted">Link analysis will compute:</p>
+    <ul class="bullet-list">
+      <li>Free-space path loss</li>
+      <li>Link margin calculations</li>
+      <li>Line-of-sight checks</li>
+      <li>Fresnel zone clearance</li>
+      <li>Relay recommendations</li>
+    </ul>
+  `;
+}
+
+function downloadCommsReport() {
+  alert('Comms report download will be implemented');
+}
+
+// ============================================================================
+// EXPORT
+// ============================================================================
+
+let exportInitialized = false;
+
+function initExport() {
+  if (exportInitialized) return;
+  exportInitialized = true;
+
+  console.log('Initializing Export...');
+
+  const exportJSONBtn = document.getElementById('exportMissionJSON');
+  if (exportJSONBtn) {
+    exportJSONBtn.addEventListener('click', exportMissionJSON);
+  }
+
+  const exportGeoBtn = document.getElementById('exportGeoJSON');
+  if (exportGeoBtn) {
+    exportGeoBtn.addEventListener('click', exportGeoJSON);
+  }
+
+  const exportCoTBtn = document.getElementById('exportCoT');
+  if (exportCoTBtn) {
+    exportCoTBtn.addEventListener('click', exportCoT);
+  }
+
+  loadExportSummary();
+  loadJSONViewer();
+}
+
+function loadExportSummary() {
+  const summaryDiv = document.getElementById('exportSummary');
+  if (!summaryDiv) return;
+
+  if (typeof MissionProjectStore !== 'undefined') {
+    const project = MissionProjectStore.loadMissionProject();
+    const platforms = project.platforms?.length || 0;
+    const phases = project.mission?.phases?.length || 0;
+    const nodes = project.nodes?.length || 0;
+
+    summaryDiv.innerHTML = `
+      <h4>${project.meta?.name || 'Unnamed Project'}</h4>
+      <p class="small muted">
+        <strong>${platforms}</strong> platform(s) ·
+        <strong>${phases}</strong> phase(s) ·
+        <strong>${nodes}</strong> node(s)
+      </p>
+    `;
+  } else {
+    summaryDiv.innerHTML = '<p class="small muted">No project loaded</p>';
+  }
+}
+
+function loadJSONViewer() {
+  const viewer = document.getElementById('jsonViewer');
+  if (!viewer) return;
+
+  if (typeof MissionProjectStore !== 'undefined') {
+    const project = MissionProjectStore.loadMissionProject();
+    viewer.value = JSON.stringify(project, null, 2);
+  } else {
+    viewer.value = '{}';
+  }
+}
+
+function exportMissionJSON() {
+  if (typeof MissionProjectStore !== 'undefined') {
+    const project = MissionProjectStore.loadMissionProject();
+    const json = JSON.stringify(project, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `mission_project_${Date.now()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}
+
+function exportGeoJSON() {
+  if (typeof MissionProjectStore !== 'undefined') {
+    const geojson = MissionProjectStore.exportGeoJSON();
+    const json = JSON.stringify(geojson, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `mission_geo_${Date.now()}.geojson`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}
+
+function exportCoT() {
+  if (typeof MissionProjectStore !== 'undefined') {
+    const cot = MissionProjectStore.exportCoTStub();
+    const xml = typeof cot === 'string' ? cot : JSON.stringify(cot, null, 2);
+    const blob = new Blob([xml], { type: 'application/xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `mission_cot_${Date.now()}.xml`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}
+
+// ============================================================================
+// INITIALIZATION
+// ============================================================================
 
 document.addEventListener('DOMContentLoaded', () => {
-  renderVersionBadges();
-  initApp();
+  console.log('Ceradon Architect initializing...');
+
+  initThemeToggle();
+  initVersionBadges();
+  initHomePage();
+
+  // Set up routing
+  window.addEventListener('hashchange', handleHashChange);
+  handleHashChange(); // Initial route
+
+  console.log('Ceradon Architect ready');
 });

--- a/index.html
+++ b/index.html
@@ -3,333 +3,118 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ceradon Architect Stack</title>
+  <title>Ceradon Architect - Offline Mission Planning</title>
   <link rel="stylesheet" href="assets/css/styles.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <style>
-    :root {
-      --gate-bg: #0f1117;
-      --gate-card: #161924;
-      --gate-border: rgba(255, 255, 255, 0.08);
-      --gate-text: #e8ecf3;
-      --gate-subtle: #a7afc3;
-      --gate-accent: #4da3ff;
-    }
-
-    #access-gate {
-      display: none;
-      min-height: 100vh;
-      background: var(--gate-bg);
-      color: var(--gate-text);
-      font-family: system-ui, -apple-system, "Inter", sans-serif;
-      padding: 48px 16px;
-      box-sizing: border-box;
-    }
-
-    body.app-locked #access-gate {
-      display: flex;
-      position: fixed;
-      inset: 0;
-      overflow-y: auto;
-      z-index: 20;
-    }
-
-    body:not(.app-locked) #access-gate {
-      display: none;
-    }
-
-    #app-root {
-      transition: filter 160ms ease, opacity 160ms ease;
-    }
-
-    body.app-locked #app-root {
-      filter: blur(4px) grayscale(0.4);
-      opacity: 0.65;
-      pointer-events: none;
-      user-select: none;
-    }
-
-    .gate-stack {
-      max-width: 560px;
-      margin: 0 auto;
-      display: grid;
-      gap: 16px;
-    }
-
-    .gate-shell {
-      max-width: 560px;
-      margin: 0 auto;
-      background: var(--gate-card);
-      border: 1px solid var(--gate-border);
-      border-radius: 16px;
-      padding: 32px;
-      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
-    }
-
-    .gate-shell h1 {
-      margin: 0 0 12px;
-      font-size: clamp(24px, 4vw, 30px);
-      line-height: 1.25;
-    }
-
-    .gate-shell p {
-      margin: 0 0 20px;
-      color: var(--gate-subtle);
-      line-height: 1.5;
-    }
-
-    .gate-form {
-      display: grid;
-      gap: 12px;
-    }
-
-    .gate-form label {
-      font-weight: 600;
-      color: var(--gate-text);
-    }
-
-    .gate-form input {
-      padding: 12px;
-      border-radius: 10px;
-      border: 1px solid var(--gate-border);
-      background: #0c0e15;
-      color: var(--gate-text);
-      font-size: 16px;
-    }
-
-    .gate-form button {
-      padding: 12px 16px;
-      border: none;
-      border-radius: 10px;
-      background: var(--gate-accent);
-      color: #0b0e17;
-      font-weight: 700;
-      font-size: 16px;
-      cursor: pointer;
-      transition: transform 120ms ease, box-shadow 120ms ease;
-    }
-
-    .gate-form button:hover {
-      transform: translateY(-1px);
-      box-shadow: 0 8px 24px rgba(77, 163, 255, 0.25);
-    }
-
-    .gate-form button:active {
-      transform: translateY(0);
-      box-shadow: none;
-    }
-
-    .error-message {
-      color: #f77b7b;
-      font-size: 14px;
-      display: none;
-    }
-  </style>
 </head>
 <body>
-  <div id="access-gate" aria-live="polite">
-    <div class="gate-stack">
-      <div class="gate-shell" role="dialog" aria-labelledby="gateTitle" aria-describedby="gateDescription">
-        <h1 id="gateTitle">Ceradon Systems — Architect Stack demos</h1>
-        <p id="gateDescription">Enter the access code provided by Ceradon Systems to unlock the Architect Stack hub and launch tools in one place.</p>
-        <div class="gate-form">
-          <label for="demo-code">Access code</label>
-          <input id="demo-code" type="password" autocomplete="off" inputmode="numeric" aria-describedby="demo-error">
-          <button id="demo-enter" type="button">Enter</button>
-          <div id="demo-error" class="error-message" role="alert">Invalid code.</div>
-          <p class="small muted">Need a code? <a href="https://ceradonsystems.com/contact" target="_blank" rel="noopener">Request a demo code</a>.</p>
-        </div>
-      </div>
-
-      <div class="gate-shell" aria-labelledby="requestTitle" aria-describedby="requestDescription">
-        <h2 id="requestTitle">Request a demo code</h2>
-        <p id="requestDescription">
-          Ceradon Systems provides controlled access to <strong>Architect Stack demos</strong> for qualified organizations.
-          Request a code to explore the live planners and see how they fit your mission profiles.
-        </p>
-        <div class="demo-request-actions">
-          <a
-            id="demo-request-button"
-            class="btn primary demo-request-btn"
-            href="https://ceradonsystems.com/contact"
-            target="_blank"
-            rel="noopener"
-          >
-            Request a demo code
-          </a>
-
-          <p class="demo-request-email">
-            Or email us at
-            <a href="mailto:contact@ceradonsystems.com?subject=Demo%20code%20request%20%E2%80%93%20Ceradon%20Architect%20Stack">contact@ceradonsystems.com</a>
-            with your organization and use case.
-          </p>
-        </div>
-      </div>
+  <header class="top-nav">
+    <div class="brand">
+      <div class="logo-dot" aria-hidden="true"></div>
+      <span class="wordmark">Ceradon Architect</span>
     </div>
+    <nav aria-label="Primary">
+      <ul class="nav-links">
+        <li><a href="/#/home" data-route="home">Home</a></li>
+        <li><a href="/#/library" data-route="library">Parts Library</a></li>
+        <li><a href="/#/platform" data-route="platform">Platform Designer</a></li>
+        <li><a href="/#/mission" data-route="mission">Mission Planner</a></li>
+        <li><a href="/#/comms" data-route="comms">Comms Validator</a></li>
+        <li><a href="/#/export" data-route="export">Export</a></li>
+      </ul>
+    </nav>
+    <button class="toggle" id="themeToggle" aria-label="Toggle light or dark theme">🌙</button>
+  </header>
+
+  <div class="version-strip" aria-label="Application version and status">
+    <span class="pill" id="appVersionBadge" data-app-version></span>
+    <span class="pill success">Offline Ready</span>
+    <span class="pill subtle" id="schemaHeaderBadge" data-schema-version></span>
   </div>
 
-  <div id="app-root">
-    <header class="top-nav">
-      <div class="brand">
-        <div class="logo-dot" aria-hidden="true"></div>
-        <span class="wordmark">Ceradon Architect</span>
-      </div>
-      <nav aria-label="Primary">
-        <ul class="nav-links">
-          <li><a href="/#/home" data-route="home">Home</a></li>
-          <li><a href="/#/workflow" data-route="workflow">Workflow</a></li>
-          <li><a href="/#/tools" data-route="tools">Tools</a></li>
-          <li><a href="/#/mission" data-route="mission">Mission Architect</a></li>
-          <li><a href="/#/demos" data-route="demos">Demos</a></li>
-          <li><a href="/#/docs" data-route="docs">Docs</a></li>
-        </ul>
-      </nav>
-      <button class="toggle" id="themeToggle" aria-label="Toggle light or dark theme">🌙</button>
-    </header>
+  <div class="context-bar" role="note">
+    <p class="small">Offline-first mission planning tool for air-gapped environments. Design platforms, plan missions, validate comms — all in your browser with zero cloud dependencies.</p>
+  </div>
 
-    <div class="version-strip" aria-label="Application version and schema version">
-      <span class="pill" id="appVersionBadge" data-app-version></span>
-      <span class="pill subtle" id="schemaHeaderBadge" data-schema-version></span>
-      <span class="pill success" id="accessBanner" hidden></span>
-    </div>
-
-    <div class="context-bar" role="note">
-      <p class="small">Small UAS / mesh / EW / sustainment planning tool for contested environments. Architect keeps mission intent, RF realities, and sustainment in one MissionProject JSON.</p>
-    </div>
-
-    <main id="app" class="view-container">
+  <main id="app" class="view-container">
+    <!-- HOME -->
     <section id="home" class="view" aria-label="Home view">
       <div class="hero">
         <div>
-          <p class="eyebrow">Ceradon Systems | Architect Stack</p>
-          <h1>Architect Stack – authoritative hub and planner chain</h1>
-          <p class="lead">Offline-first planners for nodes, UxS, meshes, sustainment, and mission cards. The hub keeps the MissionProject schema authoritative so field teams can move plans without rework or external services.</p>
+          <p class="eyebrow">Offline Mission Planning Tool</p>
+          <h1>Design. Validate. Deploy.</h1>
+          <p class="lead">Build custom sUAS platforms, plan multi-day missions with logistics, and validate RF communications — entirely offline, entirely in your browser. No cloud, no APIs, no internet required.</p>
           <div class="hero-actions">
-            <a class="btn primary" href="/#/workflow">Explore Workflow</a>
-            <a class="btn ghost" href="/#/tools">Launch Tools</a>
+            <a class="btn primary" href="/#/library">Start with Parts Library</a>
+            <button class="btn ghost" id="loadSampleMission">Load Sample Mission</button>
           </div>
-          <p class="small muted">Access-code gated demos run in-browser. No external APIs or vendor lock-in.</p>
+          <p class="small muted">All data stays local. Export mission packages as JSON. Works in air-gapped environments.</p>
         </div>
       </div>
 
-      <div class="modules-workflows" aria-label="Modules and workflows overview">
+      <div class="modules-workflows" aria-label="Workflow overview">
         <div class="mw-card">
-          <h3>Modules</h3>
-          <p class="small muted">One MissionProject JSON feeds every planner.</p>
+          <h3>Complete Offline Workflow</h3>
+          <p class="small muted">Four integrated modules, one mission package.</p>
           <ul class="bullet-list modules-list">
-            <li><strong>Mission Architect:</strong> Mission composition, constraints, AO geometry, and exports.</li>
-            <li><strong>Node Architect:</strong> Sensor nodes, payload stacking, and RF/power envelopes.</li>
-            <li><strong>UxS Architect:</strong> Platform pairing, lift margins, and sortie timing.</li>
-            <li><strong>Mesh Architect:</strong> Mesh links, relays, RF bands, and EW-aware coverage.</li>
-            <li><strong>KitSmith:</strong> Kits, sustainment, power plans, and team loadouts.</li>
+            <li><strong>Parts Library:</strong> Manage COTS component catalogs. Import inventory from CSV, search 1000+ parts, track availability and specs.</li>
+            <li><strong>Platform Designer:</strong> Build virtual platforms from components. Real-time physics validation with environmental derating for altitude, temperature, and weather.</li>
+            <li><strong>Mission Planner:</strong> Define mission phases, calculate battery swaps, generate per-operator packing lists with terrain-adjusted weight limits.</li>
+            <li><strong>Comms Validator:</strong> Analyze RF link budgets, check line-of-sight, recommend relay placement for coverage gaps.</li>
           </ul>
         </div>
         <div class="mw-card">
-          <h3>Workflows</h3>
-          <p class="small muted">Mission-first, kit-first, or RF-first chains match <a href="docs/stack_workflows.md" target="_blank" rel="noopener">stack_workflows.md</a>.</p>
+          <h3>Typical Workflow</h3>
+          <p class="small muted">Follow this path or jump to any module.</p>
           <ul class="bullet-list">
-            <li><strong>Mission-first:</strong> Mission Architect → Node Architect → UxS Architect → Mesh Architect → KitSmith.</li>
-            <li><strong>Kit/sustainment-first:</strong> KitSmith → Mission Architect → Node Architect → UxS Architect → Mesh Architect.</li>
-            <li><strong>RF-first:</strong> Mesh Architect → Mission Architect → Node Architect → UxS Architect → KitSmith.</li>
+            <li><strong>Step 1:</strong> Load your unit's inventory into Parts Library (or use sample catalog).</li>
+            <li><strong>Step 2:</strong> Design platforms in Platform Designer — select components, validate physics.</li>
+            <li><strong>Step 3:</strong> Plan your mission — define phases, calculate logistics, generate packing lists.</li>
+            <li><strong>Step 4:</strong> Validate comms — check link budgets, identify coverage gaps, place relays.</li>
+            <li><strong>Step 5:</strong> Export complete mission package as JSON for field deployment.</li>
           </ul>
-          <p class="small muted">Launch modules from the Tools view or embedded workflow below. All paths preserve the same MissionProject schema.</p>
+          <p class="small muted">All modules read/write the same MissionProject JSON. Start anywhere, work in any order.</p>
         </div>
       </div>
 
-      <div class="missionproject-callout" aria-label="MissionProject JSON overview">
-        <h3>MissionProject exchange file</h3>
-        <p class="small">All Architect tools exchange the same <code>MissionProject</code> JSON. Top-level keys stay consistent so planners can hand off between mission, RF, and sustainment without retyping.</p>
-        <pre class="code-snippet"><code>{
-  "mission": { "tasks": [], "phases": [], "assignments": [] },
-  "environment": [{ "id": "env-main", "altitudeBand": "0-600m", "temperatureBand": "5-25C" }],
-  "constraints": [],
-  "nodes": [],
-  "platforms": [],
-  "mesh_links": [],
-  "kits": []
-}</code></pre>
-        <p class="small">Schema details live in <a href="docs/mission_project_schema.md" target="_blank" rel="noopener">docs/mission_project_schema.md</a>. Imports preserve unknown keys to stay compatible across tools.</p>
-      </div>
-
-      <div class="schema-info">
-        <div class="schema-card">
-          <div class="schema-header">
-            <div>
-              <p class="eyebrow">Schema authority</p>
-              <h3>MissionProject schema v2.0.0</h3>
-              <p class="small" id="schemaVersionDetail">Schema matches the hub reference.</p>
-            </div>
-            <span class="schema-badge" id="schemaVersionBadge">2.0.0</span>
+      <div class="missionproject-callout" aria-label="Quick start guide">
+        <h3>Quick Start</h3>
+        <div class="quick-start-steps">
+          <div class="qs-step">
+            <strong>1. Parts Library</strong>
+            <p class="small">Load COTS components or import your unit's inventory from CSV.</p>
+            <a class="btn subtle" href="/#/library">Open Parts Library →</a>
           </div>
-          <p class="small">This hub is the single source of truth for MissionProject. Downstream tools preserve unknown fields and honor <code>schemaVersion</code> when round-tripping.</p>
-          <ul class="schema-roles">
-            <li><strong>Node Architect:</strong> nodes, RF/power envelopes, environment constraints.</li>
-            <li><strong>UxS Architect:</strong> platforms, payload lift/endurance, platform metrics.</li>
-            <li><strong>Mesh Architect:</strong> mesh_links, rf_bands, ew_profile, link redundancy.</li>
-            <li><strong>KitSmith:</strong> kits, sustainment, power_plan, packing_lists, load limits.</li>
-            <li><strong>Mission Architect:</strong> mission, phases, assignments, mission_cards, exports.</li>
-          </ul>
-          <p class="small">Docs: <a href="docs/mission_project_schema.md" target="_blank" rel="noopener">MissionProject schema</a> · <a href="docs/stack_workflows.md" target="_blank" rel="noopener">Stack workflows</a></p>
-          <div class="schema-warning" id="schemaWarning" hidden></div>
-        </div>
-      </div>
-
-      <div class="status-widgets" id="missionProjectHealth" aria-live="polite">
-        <div class="widget-heading">
-          <p class="eyebrow">MissionProject status</p>
-          <h3>Schema + validation check</h3>
-        </div>
-        <div class="widget-grid">
-          <div class="widget-tile">
-            <p class="small muted">Loaded schemaVersion</p>
-            <strong id="healthSchemaVersion">2.0.0</strong>
-            <p class="small">Defaults to v2.0.0 when absent.</p>
+          <div class="qs-step">
+            <strong>2. Platform Designer</strong>
+            <p class="small">Build platforms from parts, validate thrust-to-weight and flight time.</p>
+            <a class="btn subtle" href="/#/platform">Design Platform →</a>
           </div>
-          <div class="widget-tile" id="healthValidationTile">
-            <p class="small muted">Validation</p>
-            <strong id="healthValidationStatus">Checking…</strong>
-            <p class="small" id="healthValidationDetail">Validating required fields.</p>
+          <div class="qs-step">
+            <strong>3. Mission Planner</strong>
+            <p class="small">Define phases, calculate battery swaps, generate packing lists.</p>
+            <a class="btn subtle" href="/#/mission">Plan Mission →</a>
           </div>
-        </div>
-      </div>
-
-      <div class="compliance-card" aria-label="Module compliance summary">
-        <div>
-          <p class="eyebrow">Module compliance</p>
-          <h3>Who owns which MissionProject sections</h3>
-          <p class="small muted">Each tool targets MissionProject schemaVersion 2.0.0. Preserve unknown fields and keep schemaVersion tagged for downstream integrity.</p>
-        </div>
-        <div class="compliance-grid">
-          <div class="compliance-item">
-            <strong>Node Architect</strong>
-            <p class="small">Populates <code>nodes[]</code>, RF/power envelopes, and can annotate <code>environment</code> plus <code>constraints</code> with RF realities.</p>
+          <div class="qs-step">
+            <strong>4. Comms Validator</strong>
+            <p class="small">Check RF link budgets, validate line-of-sight, place relays.</p>
+            <a class="btn subtle" href="/#/comms">Validate Comms →</a>
           </div>
-          <div class="compliance-item">
-            <strong>UxS Architect</strong>
-            <p class="small">Fills <code>platforms[]</code>, lift/endurance metrics, sortie timing, and keeps <code>nodes</code> paired to rides.</p>
-          </div>
-          <div class="compliance-item">
-            <strong>Mesh Architect</strong>
-            <p class="small">Owns <code>mesh_links[]</code>, <code>rf_bands</code>, EW context, and link redundancy across contested paths.</p>
-          </div>
-          <div class="compliance-item">
-            <strong>KitSmith</strong>
-            <p class="small">Maintains <code>kits[]</code>, <code>sustainment</code>, <code>power_plan</code>, <code>packing_lists</code>, and <code>kitsSummary</code> weight limits.</p>
-          </div>
-          <div class="compliance-item">
-            <strong>Mission Architect</strong>
-            <p class="small">Defines <code>mission</code>, <code>phases</code>, <code>assignments</code>, AO constraints, <code>mission_cards</code>, and <code>exports</code>.</p>
+          <div class="qs-step">
+            <strong>5. Export</strong>
+            <p class="small">Download complete mission package as JSON for field deployment.</p>
+            <a class="btn subtle" href="/#/export">Export Package →</a>
           </div>
         </div>
       </div>
 
       <div class="missionproject-status" id="missionProjectStatusPanel" aria-live="polite">
         <div class="status-body">
-          <p class="eyebrow">MissionProject status</p>
+          <p class="eyebrow">Current Project Status</p>
           <h3 id="statusProjectName">No project loaded</h3>
-          <p class="small" id="statusProjectMeta">No MissionProject loaded. Use the demo payload to start.</p>
+          <p class="small" id="statusProjectMeta">Load a sample project or import your own to get started.</p>
           <div class="status-meta-grid">
             <div>
               <p class="small muted">Schema</p>
@@ -346,398 +131,269 @@
           </div>
         </div>
         <div class="status-actions" id="statusActions">
-          <button class="btn primary" id="homeLoadDemo" data-default-label="Load demo project">Load demo project</button>
-          <button class="btn ghost" id="homeImportProject">Import MissionProject JSON</button>
+          <button class="btn primary" id="homeLoadDemo" data-default-label="Load sample project">Load sample project</button>
+          <button class="btn ghost" id="homeImportProject">Import JSON</button>
           <button class="btn subtle" id="homeClearProject">Clear</button>
           <input type="file" id="homeImportProjectFile" accept="application/json" hidden>
         </div>
       </div>
-
     </section>
-    <section id="workflow" class="view" aria-label="Workflow view" hidden>
+
+    <!-- PARTS LIBRARY -->
+    <section id="library" class="view" aria-label="Parts Library" hidden>
       <div class="section-header">
-        <div>
-          <p class="eyebrow">Mission Workflow</p>
-          <h2>One dashboard, four modules. Move missions without leaving the shell.</h2>
-          <p class="lead">Stay on a single page to embed platform, mesh, mission, and kit planners. Update module status, keep a shared mission project JSON in localStorage, and export/import as you go.</p>
-          <p class="small muted demo-note">Demo requests stay here and on CeradonSystems.com. Embedded planners load directly without in-iframe request prompts.</p>
-        </div>
+        <p class="eyebrow">Module 1</p>
+        <h2>Parts Library</h2>
+        <p class="lead">Manage your COTS component catalog. Import unit inventory from CSV, search and filter parts, track availability and specifications.</p>
       </div>
 
-      <div class="demo-banner" id="workflowAccessBanner" hidden>Demo only — neutral COTS sample data, no real missions.</div>
-
-      <div class="workflow-guard" id="workflowGuard" data-guarded="true">
-        <div class="workflow-overlay" id="workflowAccessOverlay">
-          <div>
-            <h3>Demo access required</h3>
-            <p class="small muted">Enter the access code to unlock embedded planners and MissionProject edits.</p>
-            <p class="small subtle" id="plannerLockedNotice">Planner is locked until a valid access code is entered.</p>
-          </div>
-        </div>
-
-        <div class="workflow-dashboard">
-          <aside class="module-sidebar" id="moduleSidebar" aria-label="Workflow module navigation"></aside>
-
-          <div class="workflow-main">
-            <div class="module-panel">
-              <div class="module-panel-header">
-                <div>
-                  <p class="eyebrow" id="moduleCategory">Module</p>
-                  <h3 id="moduleTitle">Platform Designer (Node + UxS)</h3>
-                  <p class="small" id="moduleDescription"></p>
-                </div>
-                <div class="status-control">
-                  <label for="moduleStatus">Status</label>
-                  <select id="moduleStatus" aria-label="Module status selector">
-                    <option value="Not Started">Not Started</option>
-                    <option value="In Progress">In Progress</option>
-                    <option value="Complete">Complete</option>
-                  </select>
-                </div>
-              </div>
-
-              <div class="module-links" id="moduleLinks"></div>
-              <div class="embed-container" id="moduleEmbed"></div>
-            </div>
-
-            <div class="project-layout">
-              <div class="card project-card">
-                <h3>Mission project</h3>
-                <p class="small">Edit the shared mission project JSON that every module reads and writes. Values persist locally under <code>ceradon_mission_project</code>.</p>
-
-                <form class="project-form" id="projectMetaForm">
-                  <div class="form-grid">
-                    <label>Mission name
-                      <input type="text" id="missionName" name="missionName" autocomplete="off">
-                    </label>
-                    <label>Mission type (taxonomy)
-                      <select id="missionType" name="missionType"></select>
-                    </label>
-                    <label>Operating environment band
-                      <select id="environmentBand" name="environmentBand"></select>
-                    </label>
-                    <label>Environment – altitude band
-                      <select id="altitudeBand" name="altitudeBand"></select>
-                    </label>
-                    <label>Environment – temperature band
-                      <select id="temperatureBand" name="temperatureBand"></select>
-                    </label>
-                    <label>Duration (hours)
-                      <select id="durationHours" name="durationHours">
-                        <option value="24">24</option>
-                        <option value="48">48</option>
-                        <option value="72">72</option>
-                      </select>
-                    </label>
-                    <label>Inventory catalog reference
-                      <input type="text" id="inventoryReference" name="inventoryReference" autocomplete="off">
-                    </label>
-                    <label>Planned sustainment hours
-                      <input type="number" id="sustainmentHours" name="sustainmentHours" min="0" step="1">
-                    </label>
-                    <label>Per-person kit load (kg)
-                      <input type="number" id="perPersonLoad" name="perPersonLoad" min="0" step="0.5">
-                    </label>
-                    <label>Per-person weight limit (kg)
-                      <input type="number" id="perPersonLimit" name="perPersonLimit" min="0" step="0.5">
-                    </label>
-                    <label>EW level (taxonomy)
-                      <select id="ewLevel" name="ewLevel"></select>
-                    </label>
-                    <label>Comms relay count
-                      <input type="number" id="relayCount" name="relayCount" min="0" step="1">
-                    </label>
-                    <label>Critical links
-                      <input type="number" id="criticalLinks" name="criticalLinks" min="0" step="1">
-                    </label>
-                  </div>
-                </form>
-
-                <div class="project-actions">
-                  <div class="project-alert" id="projectAlert" role="status" aria-live="polite" hidden></div>
-                  <div class="action-row">
-                    <button class="btn primary" id="exportProject">Export MissionProject JSON</button>
-                    <button class="btn ghost" id="importProject">Import MissionProject JSON</button>
-                    <input type="file" id="importProjectFile" accept="application/json" hidden>
-                    <button class="btn subtle" id="exportGeo">Export GeoJSON</button>
-                    <button class="btn subtle" id="exportCoT">Export CoT Stub</button>
-                  </div>
+      <div class="tool-panel">
+        <div class="card">
+          <h3>Import / Export</h3>
           <div class="action-row">
-            <button class="btn primary" id="loadDemoProject" data-default-label="Load demo project">Load demo project</button>
-            <button class="btn ghost" id="runWhitefrostDemo" data-default-label="Run the WHITEFROST demo">Run the WHITEFROST demo</button>
-            <p class="small" id="projectStatus" aria-live="polite"></p>
+            <button class="btn primary" id="importCSV">Import CSV Inventory</button>
+            <button class="btn ghost" id="loadSampleParts">Load Sample Catalog</button>
+            <button class="btn subtle" id="exportPartsJSON">Export as JSON</button>
+            <input type="file" id="csvFileInput" accept=".csv" hidden>
           </div>
+          <p class="small muted" id="partsLibraryStatus">No parts loaded. Import a CSV or load sample catalog.</p>
         </div>
-      </div>
 
-              <div class="card editor-card" aria-label="MissionProject viewer and editor">
-                <div class="editor-header">
-                  <div>
-                    <h3>MissionProject viewer / editor</h3>
-                    <p class="small">Inspect, validate, and apply MissionProject JSON. Validation checks against <code>schema/mission_project_schema_v2.json</code>.</p>
-                  </div>
-                </div>
-                <div class="summary-panel">
-                  <p class="eyebrow">Quick summary</p>
-                  <ul class="summary-list" id="projectSummaryList"></ul>
-                </div>
-                <label class="small" for="projectJsonEditor">JSON payload</label>
-                <textarea id="projectJsonEditor" class="json-editor" rows="14" aria-label="MissionProject JSON editor"></textarea>
-                <div class="editor-actions">
-                  <button class="btn subtle" id="validateProjectJson">Validate JSON</button>
-                  <button class="btn primary" id="applyProjectJson">Apply to workspace</button>
-                  <a class="btn ghost" href="schema/mission_project_schema_v2.json" target="_blank" rel="noopener">Open schema file</a>
-                </div>
-                <ul class="editor-status" id="projectJsonErrors"></ul>
-              </div>
-
-              <div class="card feasibility-card">
-                <div class="feasibility-header">
-                  <h3>Mission Feasibility</h3>
-                  <p class="small">Reads from the stored project JSON. Color cues flag sustainment, weight, and comms coverage gaps.</p>
-                </div>
-                <div class="feasibility-items" id="feasibilityItems"></div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="tools" class="view" aria-label="Tools view" hidden>
-      <div class="section-header">
-        <p class="eyebrow">Tool hub</p>
-        <h2>All Architect modules, one launchpad</h2>
-        <p class="lead">Open live demos, check roles, and jump to the right planner without retracing steps.</p>
-      </div>
-      <div class="tool-grid" id="toolGrid" aria-live="polite"></div>
-    </section>
-
-    <section id="mission" class="view" aria-label="Mission Architect view" hidden>
-      <div class="section-header">
-        <p class="eyebrow">Mission-first entry</p>
-        <h2>Mission Architect – drive the stack from the mission down</h2>
-        <p class="lead">Compose phases, AO constraints, timelines, and outputs that downstream tools consume. This hub links directly to the existing Mission Architect app.</p>
-        <div class="mission-actions">
-          <a class="btn primary" href="https://mission.ceradonsystems.com/" target="_blank" rel="noopener">Open Mission Architect</a>
-          <a class="btn ghost" href="/#/workflow">See integrated workflow</a>
-        </div>
-      </div>
-      <div class="mission-layout">
         <div class="card">
-          <h3>How Mission Architect fits</h3>
-          <ul class="bullet-list">
-            <li><strong>Outputs → Node Architect:</strong> Convert mission phases into node packages per leg.</li>
-            <li><strong>Outputs → UxS Architect:</strong> Match nodes to UxS platforms with loadouts tied to phases.</li>
-            <li><strong>Outputs → Mesh Architect:</strong> Use AO, altitudes, and RF constraints to shape relays and backhaul.</li>
-            <li><strong>Outputs → KitSmith:</strong> Turn teams, timelines, and resupply plans into kits and sustainment loads.</li>
-          </ul>
-          <div class="sample-flow">
-            <h4>Sample mission flow</h4>
-            <p>Start with recon-in-force across two phases. Build the mission in Mission Architect, export the spec, then:</p>
-            <ol>
-              <li>Push node requirements to Node Architect for sensor stack and power checks.</li>
-              <li>Send approved nodes to UxS Architect for platform pairing and sortie planning.</li>
-              <li>Feed AO geometry into Mesh Architect for RF coverage and relay placement.</li>
-              <li>Package sustainment in KitSmith aligned to each phase and team role.</li>
-            </ol>
-            <div class="quick-links">
-              <a class="btn subtle" href="https://node.ceradonsystems.com/web/index.html" target="_blank" rel="noopener">Open Node Architect</a>
-              <a class="btn subtle" href="https://uxs.ceradonsystems.com/web/" target="_blank" rel="noopener">Open UxS Architect</a>
-              <a class="btn subtle" href="https://mesh.ceradonsystems.com/" target="_blank" rel="noopener">Open Mesh Architect</a>
-              <a class="btn subtle" href="https://kitsmith.ceradonsystems.com/" target="_blank" rel="noopener">Open KitSmith</a>
-            </div>
-            <div class="quick-links">
-              <a class="btn ghost" href="https://mission.ceradonsystems.com/print.html" target="_blank" rel="noopener">Mission Architect print view</a>
-              <a class="btn ghost" href="https://kitsmith.ceradonsystems.com/print.html" target="_blank" rel="noopener">KitSmith print view</a>
-            </div>
+          <h3>Search & Filter</h3>
+          <div class="form-grid">
+            <label>Search parts
+              <input type="text" id="partsSearch" placeholder="Search by name, manufacturer, or specs...">
+            </label>
+            <label>Category
+              <select id="partsCategoryFilter">
+                <option value="all">All Categories</option>
+                <option value="airframes">Airframes</option>
+                <option value="motors">Motors</option>
+                <option value="escs">ESCs</option>
+                <option value="batteries">Batteries</option>
+                <option value="flight_controllers">Flight Controllers</option>
+                <option value="radios">Radios</option>
+                <option value="sensors">Sensors</option>
+                <option value="accessories">Accessories</option>
+              </select>
+            </label>
           </div>
         </div>
+
         <div class="card">
-          <h3>Mission archetypes</h3>
-          <p class="small">Load doctrine-aligned MissionProject presets that mirror common Ceradon demo lanes.</p>
-          <div id="missionArchetypeList" class="archetype-list" aria-live="polite"></div>
-        </div>
-        <div class="embed-card">
-          <h3>Live preview</h3>
-          <p class="small">Embedded view loads the existing Mission Architect app. If it does not load, use the primary button above.</p>
-          <div class="embed-container">
-            <iframe title="Mission Architect" src="https://mission.ceradonsystems.com/" loading="lazy"></iframe>
+          <h3>Parts Catalog</h3>
+          <div id="partsGrid" class="parts-grid">
+            <p class="small muted">No parts to display. Import or load sample catalog.</p>
           </div>
         </div>
       </div>
     </section>
 
-    <section id="demos" class="view" aria-label="Demos view" hidden>
+    <!-- PLATFORM DESIGNER -->
+    <section id="platform" class="view" aria-label="Platform Designer" hidden>
       <div class="section-header">
-        <p class="eyebrow">Integrated demo stories</p>
-        <h2>See the stack in action</h2>
-        <p class="lead">Pre-baked walkthroughs show how missions, nodes, meshes, and kits move together.</p>
+        <p class="eyebrow">Module 2</p>
+        <h2>Platform Designer</h2>
+        <p class="lead">Build virtual UxS platforms from components. Real-time physics validation with environmental derating.</p>
       </div>
-      <div class="demo-grid" id="demoGrid" aria-live="polite"></div>
+
+      <div class="tool-panel">
+        <div class="card">
+          <h3>Platform Configuration</h3>
+          <div class="form-grid">
+            <label>Platform Name
+              <input type="text" id="platformName" placeholder="e.g., Long-Range Recon Quad">
+            </label>
+            <label>Platform Type
+              <select id="platformType">
+                <option value="multi-rotor">Multi-rotor</option>
+                <option value="fixed-wing">Fixed-wing</option>
+                <option value="vtol">VTOL</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3>Environment</h3>
+          <div class="form-grid">
+            <label>Altitude (m)
+              <input type="number" id="envAltitude" value="0" min="0" max="5000" step="100">
+            </label>
+            <label>Temperature (°C)
+              <input type="number" id="envTemperature" value="20" min="-40" max="50" step="5">
+            </label>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3>Component Selection</h3>
+          <p class="small muted">Select components from your Parts Library</p>
+          <div id="componentSelection"></div>
+        </div>
+
+        <div class="card">
+          <h3>Physics Validation</h3>
+          <div id="validationResults"></div>
+          <div class="action-row">
+            <button class="btn primary" id="validatePlatform">Validate Design</button>
+            <button class="btn ghost" id="savePlatform">Save Platform</button>
+          </div>
+        </div>
+      </div>
     </section>
 
-    <section id="docs" class="view" aria-label="Docs view" hidden>
+    <!-- MISSION PLANNER -->
+    <section id="mission" class="view" aria-label="Mission Planner" hidden>
       <div class="section-header">
-        <p class="eyebrow">Docs & About</p>
-        <h2>What is Ceradon Architect Stack?</h2>
-        <p class="lead">Architect is the planning layer between COTS UxS/robotics and the logistics/C2 stack. It keeps mission intent, RF realities, and sustainment in lockstep.</p>
-        <p class="small muted">Docs: <a href="docs/mission_project_schema.md" target="_blank" rel="noopener">MissionProject schema</a> · <a href="docs/stack_workflows.md" target="_blank" rel="noopener">Stack workflows</a> · <a href="https://ceradonsystems.com" target="_blank" rel="noopener">CeradonSystems.com</a></p>
+        <p class="eyebrow">Module 3</p>
+        <h2>Mission Planner</h2>
+        <p class="lead">Define mission phases, calculate battery swaps, generate per-operator packing lists with terrain-adjusted weight limits.</p>
       </div>
-      <div class="docs-layout">
+
+      <div class="tool-panel">
         <div class="card">
-          <h3>Modules</h3>
-          <ul class="bullet-list">
-            <li><strong>Mission Architect:</strong> Mission composition, constraints, AO geometry.</li>
-            <li><strong>Node Architect:</strong> Sensor nodes, payload stacking, power budgets.</li>
-            <li><strong>UxS Architect:</strong> Platform selection, loadouts, and sortie timing.</li>
-            <li><strong>Mesh Architect:</strong> RF backhaul, relays, gateways, spectrum assumptions.</li>
-            <li><strong>KitSmith:</strong> Sustainment kits, spares, and team packaging.</li>
-          </ul>
-        </div>
-        <div class="card">
-          <h3>How it fits Ceradon</h3>
-          <p>Architect is a neutral, COTS-focused planning layer that stays offline-first and access-code gated. Each module exports the same MissionProject JSON so teams can move between tools without rebuilding data.</p>
-          <p>For more, visit <a href="https://ceradonsystems.com" target="_blank" rel="noopener">CeradonSystems.com</a>.</p>
-          <p class="small">This site is static and GitHub Pages–ready. Edit theme tokens in <code>assets/css/styles.css</code>, update routes in <code>assets/js/app.js</code>, and add tools or demos via the data structures near the top of <code>app.js</code>.</p>
-        </div>
-        <div class="card">
-          <h3>MissionProject + TAK exports</h3>
-          <p>MissionProject JSON schema is documented in <a href="docs/mission_project_schema.md" target="_blank" rel="noopener">docs/mission_project_schema.md</a>. ATAK/Tactical-App export notes live in <a href="docs/atak_exports.md" target="_blank" rel="noopener">docs/atak_exports.md</a>.</p>
-          <p class="small">All entities are tagged with <code>origin_tool</code> to ease cross-Architect imports. Exports remain offline-first and require no external APIs.</p>
-        </div>
-        <div class="card">
-          <h3>Schema &amp; Validation</h3>
-          <p>Paste a MissionProject JSON payload and validate it against the hub schema. Invalid payloads return JSON paths with issues.</p>
-          <p class="small" id="schemaVersionDisplay">MissionProject schema v2.0.0</p>
-          <textarea id="schemaValidatorInput" class="json-editor" rows="10" aria-label="MissionProject validation input"></textarea>
-          <div class="editor-actions">
-            <button class="btn subtle" id="schemaValidateBtn">Validate</button>
-            <button class="btn primary" id="schemaApplyBtn">Apply to workspace</button>
-            <a class="btn ghost" href="schema/mission_project_schema_v2.json" target="_blank" rel="noopener">Open schema file</a>
+          <h3>Mission Details</h3>
+          <div class="form-grid">
+            <label>Mission Name
+              <input type="text" id="missionName" placeholder="e.g., Ridge Reconnaissance - 48hr">
+            </label>
+            <label>Duration (hours)
+              <input type="number" id="missionDuration" value="48" min="1" max="168" step="1">
+            </label>
+            <label>Terrain
+              <select id="missionTerrain">
+                <option value="urban">Urban</option>
+                <option value="suburban">Suburban</option>
+                <option value="rural">Rural</option>
+                <option value="mountain">Mountain</option>
+                <option value="desert">Desert</option>
+              </select>
+            </label>
+            <label>Team Size
+              <input type="number" id="teamSize" value="4" min="1" max="12" step="1">
+            </label>
           </div>
-          <div id="schemaValidationResult" class="validation-callout">Awaiting validation.</div>
-          <ul class="editor-status" id="schemaValidationErrors"></ul>
         </div>
+
         <div class="card">
-          <h3>Environment &amp; EW taxonomy</h3>
-          <p>Canonical environment bands, altitude and temperature ranges, EW levels, and mission types used across Architect tools. Workflow metadata selects from this shared list to keep planners aligned.</p>
-          <p class="small">Reference file: <code>data/environment_taxonomy.json</code>. Node, UxS, Mesh, and KitSmith are expected to mirror these enums.</p>
-          <ul class="bullet-list">
-            <li><strong>Environment bands:</strong> Indoor, dense urban, urban, suburban, rural, open.</li>
-            <li><strong>Altitude bands:</strong> 0–500m, 500–1500m, 1500–2500m, &gt;2500m.</li>
-            <li><strong>Temperature bands:</strong> -30 to -10°C, -10 to 10°C, 10 to 25°C, 25 to 40°C.</li>
-            <li><strong>EW levels:</strong> Permissive, contested, high-EW.</li>
-            <li><strong>Mission types:</strong> Mesh reconnaissance, urban lane, partner sustainment, low-infrastructure mesh.</li>
-          </ul>
+          <h3>Mission Phases</h3>
+          <div id="phasesEditor"></div>
+          <button class="btn subtle" id="addPhase">+ Add Phase</button>
         </div>
+
         <div class="card">
-          <h3>How to use this with the other tools</h3>
-          <ul class="bullet-list">
-            <li><strong>Import/export:</strong> Each planner reads the same MissionProject JSON and should preserve unknown keys.</li>
-            <li><strong>Data flow:</strong> Start mission-first, kit-first, or RF-first—see <a href="docs/stack_workflows.md" target="_blank" rel="noopener">stack_workflows.md</a> for chains.</li>
-            <li><strong>Schema fidelity:</strong> Watch the schema badge for version mismatches and validate JSON before applying.</li>
-            <li><strong>Live tools:</strong> Launchers below route to the latest live endpoints for each module.</li>
-          </ul>
+          <h3>Logistics Calculation</h3>
+          <div id="logisticsResults"></div>
+          <div class="action-row">
+            <button class="btn primary" id="calculateLogistics">Calculate Logistics</button>
+            <button class="btn ghost" id="downloadPackingLists">Download Packing Lists</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- COMMS VALIDATOR -->
+    <section id="comms" class="view" aria-label="Comms Validator" hidden>
+      <div class="section-header">
+        <p class="eyebrow">Module 4</p>
+        <h2>Comms Validator</h2>
+        <p class="lead">Analyze RF link budgets, check line-of-sight, recommend relay placement for coverage gaps.</p>
+      </div>
+
+      <div class="tool-panel">
+        <div class="card">
+          <h3>Environment</h3>
+          <div class="form-grid">
+            <label>Terrain Type
+              <select id="commsTerrain">
+                <option value="open">Open</option>
+                <option value="rural">Rural</option>
+                <option value="suburban">Suburban</option>
+                <option value="urban">Urban</option>
+                <option value="dense_urban">Dense Urban</option>
+              </select>
+            </label>
+            <label>Weather Conditions
+              <select id="commsWeather">
+                <option value="clear">Clear</option>
+                <option value="light_rain">Light Rain</option>
+                <option value="heavy_rain">Heavy Rain</option>
+                <option value="snow">Snow</option>
+                <option value="fog">Fog</option>
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3>Nodes</h3>
+          <div id="nodesEditor"></div>
+          <button class="btn subtle" id="addNode">+ Add Node</button>
+        </div>
+
+        <div class="card">
+          <h3>Link Analysis</h3>
+          <div id="linkAnalysisResults"></div>
+          <div class="action-row">
+            <button class="btn primary" id="analyzeLinks">Analyze Links</button>
+            <button class="btn ghost" id="downloadCommsReport">Download Report</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- EXPORT -->
+    <section id="export" class="view" aria-label="Export" hidden>
+      <div class="section-header">
+        <p class="eyebrow">Module 5</p>
+        <h2>Export Mission Package</h2>
+        <p class="lead">Download your complete mission package as JSON, GeoJSON, or CoT for field deployment.</p>
+      </div>
+
+      <div class="tool-panel">
+        <div class="card">
+          <h3>Current Mission Project</h3>
+          <div id="exportSummary"></div>
+        </div>
+
+        <div class="card">
+          <h3>Export Options</h3>
+          <div class="action-row">
+            <button class="btn primary" id="exportMissionJSON">Export MissionProject JSON</button>
+            <button class="btn ghost" id="exportGeoJSON">Export GeoJSON</button>
+            <button class="btn subtle" id="exportCoT">Export CoT Stub</button>
+          </div>
+        </div>
+
+        <div class="card">
+          <h3>Mission Project Viewer</h3>
+          <textarea id="jsonViewer" class="json-editor" rows="20" readonly></textarea>
         </div>
       </div>
     </section>
   </main>
 
-  <section class="change-log-section" aria-label="Change log">
-    <details>
-      <summary>Change Log</summary>
-      <div id="changeLogEntries" class="change-log"></div>
-    </details>
-  </section>
-
   <footer class="site-footer">
-    <div class="footer-links">
-      <a href="https://ceradonsystems.com" target="_blank" rel="noopener">CeradonSystems.com</a>
-      <a href="https://node.ceradonsystems.com/web/index.html" target="_blank" rel="noopener">Node Architect</a>
-      <a href="https://uxs.ceradonsystems.com/web/" target="_blank" rel="noopener">UxS Architect</a>
-      <a href="https://mesh.ceradonsystems.com/" target="_blank" rel="noopener">Mesh Architect</a>
-      <a href="https://kitsmith.ceradonsystems.com/" target="_blank" rel="noopener">KitSmith</a>
-      <a href="https://mission.ceradonsystems.com/" target="_blank" rel="noopener">Mission Architect</a>
-    </div>
     <div class="footer-meta">
       <span data-app-version></span>
       <span class="divider">•</span>
       <span data-schema-version></span>
     </div>
-    <p class="small">Ceradon Systems LLC – COTS-friendly RF and UxS planning tools.</p>
+    <p class="small">Ceradon Architect — Offline-first mission planning for contested environments</p>
   </footer>
-  </div>
 
+  <!-- Load offline modules first -->
+  <script src="assets/js/parts_library.js"></script>
+  <script src="assets/js/physics_engine.js"></script>
+  <script src="assets/js/platform_designer.js"></script>
+  <script src="assets/js/mission_planner.js"></script>
+  <script src="assets/js/comms_validator.js"></script>
+  <script src="assets/js/csv_importer.js"></script>
+
+  <!-- Then load MissionProject store and main app -->
   <script src="assets/js/mission_project.js"></script>
   <script src="assets/js/app.js"></script>
-  <script>
-    (() => {
-      const ACCESS_CODE = window.DEMO_ACCESS_CODE || "ARC-STACK-761";
-      const STORAGE_KEY = window.DEMO_ACCESS_KEY || "ceradon_architect_access_granted";
-      const LEGACY_KEY = window.LEGACY_ACCESS_KEY || "ceradon_demo_code";
-      const gate = document.getElementById("access-gate");
-      const appRoot = document.getElementById("app-root");
-      const input = document.getElementById("demo-code");
-      const submit = document.getElementById("demo-enter");
-      const error = document.getElementById("demo-error");
-
-      const accessBanner = document.getElementById("accessBanner");
-
-      function renderAccessBanner(isGranted) {
-        if (!accessBanner) return;
-        if (!isGranted) {
-          accessBanner.hidden = true;
-          accessBanner.textContent = '';
-          return;
-        }
-        accessBanner.textContent = 'Demo access granted — planners unlocked';
-        accessBanner.hidden = false;
-      }
-
-      function setLocked(isLocked) {
-        document.body.classList.toggle("app-locked", isLocked);
-        renderAccessBanner(!isLocked);
-        if (!isLocked && error) {
-          error.style.display = "none";
-          error.textContent = '';
-        }
-      }
-
-      function handleAuth() {
-        const value = (input?.value || "").trim();
-        if (value === ACCESS_CODE) {
-          localStorage.setItem(STORAGE_KEY, 'true');
-          localStorage.removeItem(LEGACY_KEY);
-          setLocked(false);
-          window.dispatchEvent(new Event("ceradon-demo-authorized"));
-        } else {
-          if (error) {
-            error.style.display = "block";
-            error.textContent = 'Invalid code.';
-          }
-        }
-      }
-
-      document.addEventListener("DOMContentLoaded", () => {
-        const storedValue = localStorage.getItem(STORAGE_KEY) || localStorage.getItem(LEGACY_KEY);
-        const authorized = storedValue === "true" || storedValue === ACCESS_CODE;
-        if (authorized) {
-          localStorage.setItem(STORAGE_KEY, 'true');
-        }
-        setLocked(!authorized);
-
-        window.applyWorkflowGuard?.();
-
-        submit?.addEventListener("click", handleAuth);
-        input?.addEventListener("keydown", (event) => {
-          if (event.key === "Enter") {
-            event.preventDefault();
-            handleAuth();
-          }
-        });
-      });
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
Major redesign focused on making the offline tools the actual product:

**Removed:**
- Access gate and demo code requirements
- All external links to ceradonsystems.com demos
- Marketing-focused content and module descriptions
- Old workflow/tools/demos/docs sections

**Added:**
- Clean, app-focused landing page with workflow guide
- New navigation: Parts Library, Platform Designer, Mission Planner, Comms Validator, Export
- Full UI structure for all offline modules
- Parts Library UI with CSV import, search/filter, and sample catalog loading
- Placeholder UIs for other modules ready for implementation

**Updated:**
- README to reflect new offline-first app structure
- app.js completely rewritten with new routing and module initialization
- index.html redesigned from scratch for cleaner structure

The site now functions as an actual offline planning tool playground instead
of just marketing links to external demos.