### PR TITLE
Add version tracking and comprehensive changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,149 @@
-# Ceradon Architect Hub – Change Log
+# Changelog
 
-## v1.3.0 – 2024-11-05
+All notable changes to Ceradon Architect will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Offline Tool
+- Nothing yet
+
+### Web Playground
+- Nothing yet
+
+---
+
+## [0.3.0-alpha.2] - 2026-01-07
+
+### Offline Tool
+
+#### Added
+- **Sample Data System**
+  - 40+ realistic COTS components with actual specs and pricing
+  - Sample catalog includes: airframes, motors, ESCs, batteries, flight controllers, radios, sensors, accessories
+  - One-click sample project loader creates complete demo workflow
+  - Pre-configured platform designs (X500 ISR Quadcopter, Skywalker X8 Long Range)
+  - 48-hour ISR mission scenario with 6 phases
+  - 3-node communications network (GCS, UAV, Relay)
+
+- **Export Module**
+  - Comprehensive mission package export as JSON
+  - Project status dashboard showing all modules
+  - Validation status indicators for platforms and comms networks
+  - Metadata tracking (total parts, platforms, missions, analyses)
+
+- **Platform Designer**
+  - Component selection from Parts Library with live updates
+  - Real-time physics validation with PhysicsEngine integration
+  - Environmental derating for altitude and temperature effects
+  - Detailed metrics: AUW, T/W ratio, flight time (nominal + adjusted)
+  - Error, warning, and recommendation system
+  - Platform design persistence to localStorage
+
+- **Mission Planner**
+  - Mission phase editor (add/remove phases)
+  - Battery requirements calculator from platform designs
+  - Battery swap schedule generation
+  - Per-operator packing lists with terrain-adjusted weight limits
+  - Role-specific equipment assignments
+  - Packing list CSV export
+  - Feasibility analysis with errors and warnings
+
+- **Comms Validator**
+  - Node editor with location and radio specifications
+  - RF link budget calculations (FSPL, LOS, Fresnel zone)
+  - Terrain and weather attenuation modeling
+  - Link quality assessment (excellent/good/marginal/poor/no LOS)
+  - Coverage gap identification
+  - Relay placement recommendations
+  - Detailed comms analysis report download
+
+- **Physics Engine**
+  - Air density calculations using ISA model
+  - Thrust reduction at altitude
+  - Battery capacity derating for temperature
+  - All-Up Weight (AUW) calculations
+  - Thrust-to-Weight ratio validation
+  - Power budget estimation
+  - Flight time prediction
+
+### Web Playground
+
+#### Added
+- Complete redesign as functional playground mirroring offline tool
+- Single-page application with hash-based routing
+- All 4 offline modules now functional in browser
+- Sample data loads with one click
+- Real physics validation
+- Interactive UIs for all modules
+- Export module with comprehensive project status
+
+#### Removed
+- Access gate system (159 lines)
+- External demo links
+- Marketing-focused placeholder content
+
+#### Changed
+- Home page focuses on workflow overview
+- All modules functional instead of placeholders
+
+#### Fixed
+- CSS for new UI elements
+- Form styles and button states
+- Validation result displays
+
+---
+
+## Previous Releases (Marketing Hub)
+
+### v1.3.0 – 2024-11-05
 - Hardened the demo access gate (client-side validation, no public code display, localStorage grant flag).
 - Added schema validation console in Docs with MissionProject JSON paste/apply flow.
 - Published canonical environment/EW taxonomy and wired workflow metadata to the shared enums.
 - Added mission archetype presets (WHITEFROST ridge, urban high-EW lane, partner sustainment, low-infrastructure mesh).
 - Surfaced Architect Hub Web v1.3 versioning in UI and documentation.
 
-## v0.4.0 – 2024-06-06
+### v0.4.0 – 2024-06-06
 - Added version and schema badges with mirrored footer metadata.
 - Introduced access overlays, status cards, and timestamps for MissionProject.
 - Consolidated modules/workflows copy and added a collapsible change log.
 
-## v0.3.1 – 2024-05-20
+### v0.3.1 – 2024-05-20
 - Refined MissionProject validation, summaries, and schema warnings.
 - Improved embedded workflow navigation and module status tracking.
 
-## v0.3.0 – 2024-05-05
+### v0.3.0 – 2024-05-05
 - Initial static hub with MissionProject storage, exports, and tool launchers.
+
+---
+
+## Roadmap
+
+### v0.4.0-alpha.1 (Target: Feb 2026)
+- Electron packaging for desktop distribution
+- Comprehensive error handling
+- Offline installers (Windows, macOS, Linux)
+- User documentation
+- Settings panel
+- Undo/redo functionality
+
+### v0.5.0-alpha.1 (Target: Mar 2026)
+- Import/export improvements
+- Advanced filtering in Parts Library
+- Platform comparison tool
+- Mission timeline visualization
+- Comms network map
+
+### v0.9.0-beta.1 (Target: Q2 2026)
+- Feature freeze
+- External user testing
+- Performance optimization
+- Full documentation
+
+### v1.0.0 (Target: Q3 2026)
+- First stable release
+- Production installers
+- Complete user manual
+- Video tutorials

--- a/README.md
+++ b/README.md
@@ -1,18 +1,37 @@
 # Ceradon Architect - Offline Mission Planning Tool
 
+![Version](https://img.shields.io/badge/version-0.3.0--alpha.2-orange)
+![Stage](https://img.shields.io/badge/stage-alpha-red)
+![Schema](https://img.shields.io/badge/schema-v2.0.0-blue)
+![License](https://img.shields.io/badge/license-proprietary-lightgrey)
+
 **Fully Offline Mission Planning for Air-Gapped Environments**
 
 Ceradon Architect is a professional, offline-first web application for sUAS mission planning in contested environments. Build custom platforms from COTS components, plan multi-day missions with logistics, and validate RF communications — entirely in your browser with zero cloud dependencies.
 
 **Live Demo:** <https://architect.ceradonsystems.com> (GitHub Pages)
 
-## What's New (v2.0)
+> **⚠️ Alpha Software** - Version 0.3.0-alpha.2. Under active development. Not recommended for production use. See [CHANGELOG.md](CHANGELOG.md) for details.
 
-This is a **complete redesign** focused on making the offline tools the actual product, not just marketing links:
+## What's New (v0.3.0-alpha.2)
 
-- **Removed:** Access gates, external demo links, marketing content
-- **Added:** Full interactive UIs for all offline modules
-- **Focus:** Actual mission planning tool, not a demo hub
+**One-Click Sample Project** - Load 40+ COTS components, 2 validated platforms, a 48-hour ISR mission, and 3-node comms network instantly.
+
+**Complete Module UIs:**
+- ✅ **Parts Library** - Browse, search, import CSV, load sample catalog
+- ✅ **Platform Designer** - Real-time physics validation with environmental derating
+- ✅ **Mission Planner** - Battery calculations, packing lists, logistics
+- ✅ **Comms Validator** - RF link budgets, LOS checks, relay recommendations
+- ✅ **Export Module** - Download complete mission package as JSON
+
+**Key Features:**
+- 40+ realistic COTS components (motors, batteries, radios, sensors)
+- Physics-based validation (thrust-to-weight, flight time, altitude effects)
+- Terrain-adjusted packing lists for multi-day missions
+- RF link analysis with line-of-sight and Fresnel zone calculations
+- Zero cloud dependencies - works 100% offline
+
+See [CHANGELOG.md](CHANGELOG.md) for complete details.
 
 ## Quick Start
 

--- a/version.json
+++ b/version.json
@@ -1,0 +1,94 @@
+{
+  "offline": {
+    "version": "0.3.0-alpha.2",
+    "stage": "alpha",
+    "released": "2026-01-07",
+    "description": "Offline mission planning tool for air-gapped environments",
+    "features": {
+      "partsLibrary": {
+        "status": "stable",
+        "version": "1.0.0",
+        "notes": "IndexedDB storage, CSV import, sample catalog"
+      },
+      "platformDesigner": {
+        "status": "beta",
+        "version": "1.0.0",
+        "notes": "Physics validation, environmental derating complete"
+      },
+      "missionPlanner": {
+        "status": "beta",
+        "version": "1.0.0",
+        "notes": "Battery calculations, packing lists functional"
+      },
+      "commsValidator": {
+        "status": "beta",
+        "version": "1.0.0",
+        "notes": "RF link budgets, LOS checks, relay recommendations"
+      },
+      "export": {
+        "status": "alpha",
+        "version": "0.5.0",
+        "notes": "JSON export works, GeoJSON/CoT stubs only"
+      }
+    },
+    "requirements": {
+      "node": ">=16.0.0",
+      "platforms": ["Windows", "macOS", "Linux"]
+    },
+    "nextMilestone": {
+      "version": "0.4.0-alpha.1",
+      "targetDate": "2026-02-01",
+      "goals": [
+        "Comprehensive error handling",
+        "Electron packaging",
+        "Offline installers for all platforms",
+        "User documentation started"
+      ]
+    },
+    "targetBeta": "2026-Q2",
+    "targetRelease": "2026-Q3"
+  },
+  "webPlayground": {
+    "version": "0.5.0-alpha.1",
+    "stage": "alpha",
+    "released": "2026-01-07",
+    "description": "Interactive web demo mirroring offline tool functionality",
+    "url": "https://architect.ceradonsystems.com",
+    "purpose": "Marketing and demonstration",
+    "syncedWith": "offline:0.3.0-alpha.2",
+    "features": {
+      "allModules": "functional",
+      "sampleData": "included",
+      "interactiveDemo": "complete"
+    },
+    "nextMilestone": {
+      "version": "1.0.0-beta.1",
+      "targetDate": "2026-02-15",
+      "goals": [
+        "Polish UI/UX",
+        "Add interactive tutorials",
+        "Performance optimization",
+        "Mobile responsiveness"
+      ]
+    }
+  },
+  "schemas": {
+    "missionProject": {
+      "version": "2.0.0",
+      "stable": true,
+      "breaking": false,
+      "description": "Central mission data structure"
+    },
+    "partsLibrary": {
+      "version": "1.0.0",
+      "stable": true,
+      "breaking": false,
+      "description": "COTS component catalog format"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nbschultz97/Ceradon-Architect"
+  },
+  "changelog": "CHANGELOG.md"
+}


### PR DESCRIPTION
- Add version.json with current status (v0.3.0-alpha.2)
  * Offline tool tracked separately from web playground
  * Module-level status tracking (alpha/beta/stable)
  * Roadmap with target dates for v0.4, v0.5, beta, and v1.0
  * Schema versioning (MissionProject v2.0.0, PartsLibrary v1.0.0)

- Update CHANGELOG.md to Keep a Changelog format
  * Document all v0.3.0-alpha.2 features in detail
  * Preserve previous marketing hub releases
  * Add roadmap section with future milestones

- Update README.md with version badges
  * Add shields.io badges for version, stage, schema
  * Alpha software warning
  * Updated 'What's New' section for v0.3.0-alpha.2
  * Link to CHANGELOG.md

Version tracking now follows semantic versioning with clear alpha → beta → RC → stable progression.