### PR TITLE
Governance & demo posture: add Apache‑2.0, maintainer docs, remove CNAME and neutralize UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0-alpha.2] - 2026-01-09
+
+### Offline Tool + Web Playground (SYNCED)
+
+#### Added
+- Governance, contributing, security reporting, and disclaimer documents to clarify individual maintenance and contribution flow.
+- Apache-2.0 license for open-source distribution.
+
+#### Changed
+- Demo hosting posture updated to GitHub Pages default domain with explicit no-endorsement banner/footer.
+- README updated with maintainer attribution, disclaimer language, and bring-your-own inventory model.
+- Demo UI copy scrubbed of organization funnel language and email contact.
+- Sample data updated to remove access-code phrasing.
+- Web metadata updated to point to the neutral demo URL.
+
+#### Removed
+- Custom domain CNAME from the repository.
+
+---
+
 ## [0.4.0-alpha.1] - 2026-01-08
 
 ### Offline Tool + Web Playground (SYNCED)

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-architect.ceradonsystems.com

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Thanks for contributing to Ceradon Architect.
+
+## Local development
+This repo is a static single-page app. Serve it locally with:
+
+```bash
+python -m http.server 8000
+```
+
+Then open: <http://localhost:8000>
+
+## Pull request workflow
+1. Fork the repo and create a feature branch.
+2. Make focused changes with clear commit messages.
+3. Update documentation and sample data when behavior changes.
+4. Ensure the demo remains offline-first and uses generic sample data only.
+5. Open a PR describing the change, tests run, and any deployment notes.
+
+## Standards
+- Keep UI text neutral and avoid endorsement or operational claims.
+- Preserve schema compatibility whenever possible.
+- Use small, well-scoped commits and update `CHANGELOG.md` for release-facing changes.
+
+## Testing
+No automated test suite is bundled. If you add tests, document how to run them.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,10 @@
+# Disclaimer
+
+Ceradon Architect is an open-source demo maintained by **Noah Schultz (individual)**.
+
+- **No endorsement:** Not affiliated with or endorsed by DoD/USG/NPS/SOCPAC/CRUSER.
+- **Demo-only content:** Data and scenarios are example placeholders and do not represent real operations.
+- **No operational claims:** This software is provided as-is without warranties or certifications.
+- **No agency relationship:** Use of this software does not create any agency, partnership, or contractual relationship.
+
+Use at your own risk. For production or sensitive use, perform your own security and operational review.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,21 @@
+# Governance
+
+## Maintainer
+Ceradon Architect is maintained by **Noah Schultz (individual)**.
+
+## Decision making
+- The maintainer makes final decisions on roadmap, releases, and governance.
+- Significant changes should be discussed in a GitHub issue or PR before merging.
+
+## Contributions and review
+- Contributions are welcome through pull requests.
+- The maintainer reviews PRs for scope, security posture, and offline-first compatibility.
+- Changes that affect data formats or export behavior require clear documentation updates.
+
+## Release process
+- Releases are tagged from the default branch.
+- The changelog is updated for every release.
+- Version bumps follow semantic versioning with pre-release tags where appropriate.
+
+## Code of conduct
+This project follows the GitHub community standards for respectful collaboration.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,24 @@
 # Ceradon Architect - Offline Mission Planning Tool
 
-![Version](https://img.shields.io/badge/version-0.3.0-blue)
-![Stage](https://img.shields.io/badge/stage-baseline-green)
+![Version](https://img.shields.io/badge/version-0.4.0--alpha.2-blue)
+![Stage](https://img.shields.io/badge/stage-alpha-orange)
 ![Schema](https://img.shields.io/badge/schema-v2.0.0-blue)
-![License](https://img.shields.io/badge/license-proprietary-lightgrey)
-![Air-Gap](https://img.shields.io/badge/air--gap-compliant-success)
+![License](https://img.shields.io/badge/license-Apache--2.0-blue)
+![Air-Gap](https://img.shields.io/badge/air--gap-ready-success)
 
 **Fully Offline Mission Planning for Air-Gapped Environments**
 
 Ceradon Architect is a professional, offline-first web application for sUAS mission planning in contested environments. Build custom platforms from COTS components, plan multi-day missions with logistics, and validate RF communications — entirely in your browser with **zero cloud dependencies**.
 
-**Live Demo:** <https://architect.ceradonsystems.com> (GitHub Pages)
+Maintained by **Noah Schultz (individual)**.
 
-> **✅ v0.3.0 Baseline** - Environmentally aware intelligence engine for air-gapped operations. Offline GIS, historical weather almanac, and enhanced cold-weather derating. See [v0.3_offline_gis_almanac.md](docs/v0.3_offline_gis_almanac.md) for full documentation.
+> **Not affiliated with or endorsed by DoD/USG/NPS/SOCPAC/CRUSER.** Demo-only content with example data.
 
-## What's New in v0.3.0 🗺️
+**Live Demo:** <https://nbschultz97.github.io/Ceradon-Architect/> (GitHub Pages)
+
+> **✅ v0.4.0-alpha.2** - Offline GIS, historical weather almanac, and enhanced cold-weather derating. See [v0.3_offline_gis_almanac.md](docs/v0.3_offline_gis_almanac.md) for full documentation.
+
+## What's New in v0.4.0-alpha.2 🗺️
 
 **Offline GIS & Coordinate Automation:**
 - ✅ **Interactive Map Viewer** - Leaflet-based offline mapping with click-to-select location picker
@@ -37,11 +41,11 @@ Ceradon Architect is a professional, offline-first web application for sUAS miss
 - ✅ **Arctic Mission Support** - At -40°C: 5% battery capacity with CRITICAL failure warning
 - ✅ **Real-Time Validation** - Battery derating instantly propagates to flight time and logistics
 
-**Security Hardening & Air-Gap Compliance:**
+**Security Posture & Air-Gap Notes:**
 - ✅ **100% Client-Agnostic** - No hard-coded units, exercises, or locations (generic demo data only)
-- ✅ **"Empty Ledger" Model** - Units load sensitive inventory via CSV locally
-- ✅ **Offline-First Validated** - Zero external API calls, runs on disconnected ruggedized laptops
-- ✅ **Security Audited** - See [SECURITY_AUDIT_v0.3.md](SECURITY_AUDIT_v0.3.md) for certification
+- ✅ **Skeleton Engine / Bring-Your-Own Inventory** - Load inventory locally via CSV/XLSX after install
+- ✅ **Offline-First Architecture** - Zero external API calls; runs on disconnected laptops with local assets
+- ✅ **Self-Review Notes** - See [SECURITY_AUDIT_v0.3.md](SECURITY_AUDIT_v0.3.md) for a non-certifying checklist
 
 **Doctrinal Reporting & ATAK Interoperability:**
 - ✅ **SALUTE Reports** - Pre-filled tactical reports from mission data
@@ -56,7 +60,7 @@ Ceradon Architect is a professional, offline-first web application for sUAS miss
 
 **What's New (Previous: v0.3.0-alpha.2)**
 
-**One-Click Sample Project** - Load 40+ COTS components, 2 validated platforms, a 48-hour ISR mission, and 3-node comms network instantly.
+**One-Click Sample Project** - Load 40+ COTS components, 2 sample platforms, a 48-hour recon mission, and 3-node comms network instantly.
 
 **Complete Module UIs:**
 - ✅ **Parts Library** - Browse, search, import CSV, load sample catalog
@@ -93,7 +97,7 @@ Navigate with hash routes:
 
 ### Demo Site vs Production Deployment
 
-**GitHub Pages Demo** ([architect.ceradonsystems.com](https://architect.ceradonsystems.com)):
+**GitHub Pages Demo** ([nbschultz97.github.io/Ceradon-Architect](https://nbschultz97.github.io/Ceradon-Architect/)):
 - ✅ All features functional online
 - ✅ Map viewer, environmental almanac, and SRTM elevation work
 - ⚠️ Leaflet loads from CDN (requires internet for first load)
@@ -506,6 +510,10 @@ MissionPlanner.downloadSummaryReport(mission);
 - **Implementation Plan:** `docs/IMPLEMENTATION_PLAN.md` - Full architectural roadmap
 - **Parts Library Schema:** `schema/parts_library_schema.json`
 - **Sample Data:** `data/sample_parts_library.json` - Realistic COTS components
+- **Governance:** `GOVERNANCE.md`
+- **Contributing:** `CONTRIBUTING.md`
+- **Security Reporting:** `SECURITY.md`
+- **Disclaimer:** `DISCLAIMER.md`
 
 ---
 
@@ -517,29 +525,21 @@ The site is fully static and GitHub Pages-compatible:
 - Works offline once cached by the browser
 - All modules are self-contained JavaScript files
 
+**GitHub Pages setup (default domain):**
+1. In GitHub repo settings, open **Pages**.
+2. Set **Source** to `Deploy from a branch`.
+3. Select the `main` branch and `/ (root)` folder.
+4. Save and use the published URL: `https://nbschultz97.github.io/Ceradon-Architect/`.
+
 ---
 
-## Security & Compliance
+## Security Notes
 
-**v0.3.0 Security Certification:** ✅ **APPROVED FOR AIR-GAPPED DEPLOYMENT**
+Ceradon Architect is built to avoid external dependencies and keep data local to the browser. The project includes a non-certifying, self-review checklist in [SECURITY_AUDIT_v0.3.md](SECURITY_AUDIT_v0.3.md); it is not an accreditation or operational approval.
 
-The Ceradon Architect Stack has undergone comprehensive security hardening and baseline validation. See [SECURITY_AUDIT_v0.3.md](SECURITY_AUDIT_v0.3.md) for the full audit report.
-
-**Key Security Features:**
-- ✅ **Zero External Dependencies** - No CDN calls, API requests, or cloud services
+**Security Highlights:**
+- ✅ **Zero External Dependencies** - No CDN calls, API requests, or cloud services when deployed offline
 - ✅ **Client-Agnostic Design** - Generic "Empty Ledger" model with scrubbed client references
-- ✅ **CSV Import Security** - Validated input sanitization for sensitive unit inventory ingestion
+- ✅ **CSV Import Hygiene** - Input validation and schema checks for local inventory ingestion
 - ✅ **Local-Only Storage** - All data in browser localStorage and IndexedDB
-- ✅ **Offline-First Architecture** - Fully functional without internet connectivity
-
-**Cleared For:**
-- Sensitive unit property book ingestion via CSV
-- Offline mission planning in contested environments
-- Partner force demonstrations with generic demo parts
-- Field deployment on ruggedized laptops without internet
-
-**Security Posture:** COMPLIANT
-**Operational Readiness:** READY
-**Certification Date:** 2026-01-08
-
-See the comprehensive [Security Audit Report](SECURITY_AUDIT_v0.3.md) for validation details, architecture verification, and environmental derating test results.
+- ✅ **Offline-First Architecture** - Fully functional without internet connectivity when assets are bundled

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a vulnerability
+Please report security issues via a **GitHub Security Advisory**:
+1. Go to the repository on GitHub.
+2. Click **Security** → **Advisories** → **New draft advisory**.
+3. Provide reproduction steps and any relevant logs.
+
+If the advisory workflow is not available, open a GitHub issue with minimal details and request a private follow-up.
+
+## Response expectations
+- Acknowledge receipt within 7 days.
+- Provide a remediation plan or mitigation guidance as appropriate.
+
+## Supported versions
+Only the default branch is actively maintained.

--- a/SECURITY_AUDIT_v0.3.md
+++ b/SECURITY_AUDIT_v0.3.md
@@ -1,4 +1,4 @@
-# Ceradon Architect v0.3 Security Hardening & Baseline Validation
+# Ceradon Architect v0.3 Security Hardening & Baseline Review
 
 **Date:** 2026-01-08
 **Branch:** `claude/v0.3-security-hardening-V7JFt`
@@ -8,18 +8,18 @@
 
 ## Executive Summary
 
-✅ **VALIDATION COMPLETE** - The Ceradon Architect Stack v0.3 has been audited and hardened for operational security and air-gap deployment.
+✅ **SELF-REVIEW SUMMARY** - This is a non-certifying checklist of observed behaviors during local testing. It is not an accreditation or operational approval.
 
 ### Key Findings:
 - **Data Propagation:** ✅ VERIFIED - All modules communicate correctly via event system
-- **Physics Engine:** ✅ FULLY FUNCTIONAL - Environmental derating for altitude/temperature operational
+- **Physics Engine:** ✅ FULLY FUNCTIONAL - Environmental derating for altitude/temperature
 - **Air-Gap Compliance:** ✅ ACHIEVED - All external dependencies removed
 - **Client Agnosticism:** ✅ ACHIEVED - Sensitive references scrubbed from presets
-- **Doctrinal Exports:** ✅ OPERATIONAL - SALUTE, 16-line, Spot, CoT/GeoJSON working
+- **Doctrinal Exports:** ✅ FUNCTIONAL - SALUTE, 16-line, Spot, CoT/GeoJSON working
 
 ---
 
-## 1. DATA PROPAGATION VALIDATION
+## 1. DATA PROPAGATION CHECKS
 
 ### ✅ Platform Designer → Mission Planner Flow
 
@@ -92,7 +92,7 @@
 - Change event listeners properly attached
 - Values update design.environment in real-time
 
-**Verdict:** ✅ Environmental derating is fully operational and properly integrated.
+**Verdict:** ✅ Environmental derating is fully functional and properly integrated.
 
 ---
 
@@ -188,7 +188,7 @@
 - Generates per-phase cards with platforms and simple instructions
 - Note: Full icon library and print-optimized PDF pending future release
 
-**Verdict:** ✅ All critical doctrinal exports are operational. ATAK interoperability ready.
+**Verdict:** ✅ All critical doctrinal exports are functional. ATAK interoperability ready.
 
 ---
 
@@ -230,7 +230,7 @@
 
 **Cross-Module Event System:** ✅ Operational
 - Event bus: `mission_project_events.js`
-- Auto-propagation between modules working (validated in Section 1)
+- Auto-propagation between modules working (checked in Section 1)
 
 **Verdict:** ✅ Application adheres to "Workflow Option B" architecture.
 
@@ -296,7 +296,7 @@
 - ✅ Functionally complete for mission planning
 - ✅ Secure for air-gapped deployment
 - ✅ Client-agnostic and ready for generic demonstration
-- ✅ Compliant with "Digital Construction Foreman" validation paradigm
+- ✅ Aligned with the "Digital Construction Foreman" validation paradigm
 - ✅ Interoperable with ATAK and doctrinal reporting standards
 
 **Cleared for:**
@@ -305,8 +305,8 @@
 - Partner force demonstrations with generic demo parts
 - Field deployment on ruggedized laptops without internet
 
-**Security Posture:** COMPLIANT
-**Operational Readiness:** READY
+**Security Posture:** SELF-REVIEWED
+**Operational Readiness:** NOT ASSESSED
 **Recommendation:** APPROVE FOR v0.3 RELEASE
 
 ---

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,7 +1,7 @@
 // Ceradon Architect - Offline Mission Planning Tool
 // Routes: home, library, platform, mission, comms, map, export
 
-const APP_VERSION = 'Ceradon Architect v0.3 - Offline GIS';
+const APP_VERSION = 'Ceradon Architect v0.4.0-alpha.2';
 const SCHEMA_VERSION = 'MissionProject v2.0.0';
 
 // ============================================================================
@@ -151,8 +151,8 @@ async function loadSampleMission() {
 
     alert('✅ Sample project loaded!\n\n' +
           '• 40+ COTS parts in catalog\n' +
-          '• 2 validated platform designs\n' +
-          '• 48-hour ISR mission plan\n' +
+          '• 2 sample platform designs\n' +
+          '• 48-hour recon mission plan\n' +
           '• 3-node comms network\n\n' +
           'Explore each module to see the data!');
 

--- a/assets/js/mission_project.js
+++ b/assets/js/mission_project.js
@@ -23,7 +23,7 @@ const MissionProjectStore = (() => {
       origin_tool: 'hub',
       scenario: '',
       inventoryReference: 'Pending catalog reference',
-      accessCode: 'Request via Ceradon',
+      accessCode: '',
       team: { size: 0, roles: [] }
     },
     environment: [

--- a/data/demo_mission_project.json
+++ b/data/demo_mission_project.json
@@ -8,7 +8,6 @@
     "origin_tool": "hub",
     "scenario": "Sample training lane",
     "inventoryReference": "DEMO-COTS-001",
-    "accessCode": "Request via Ceradon",
     "team": { "size": 4, "roles": ["Team lead", "UxS operator", "Payload tech", "Mesh lead"] }
   },
   "environment": [
@@ -49,7 +48,7 @@
     },
     {
       "id": "demo-sensor",
-      "name": "Portable ISR payload",
+      "name": "Portable recon payload",
       "role": "EO/IR overwatch",
       "rf": { "band": "2.4 GHz", "powerW": 4 },
       "power": "UxS bus",
@@ -78,7 +77,7 @@
       "id": "demo-fixedwing",
       "name": "Light fixed-wing",
       "type": "Fixed-wing",
-      "role": "Wide-area ISR + relay",
+      "role": "Wide-area recon + relay",
       "rf_bands": ["L/S", "2.4 GHz"],
       "power": "4S Li-ion",
       "battery": { "capacityWh": 200, "lowTempLimitC": -5 },
@@ -142,7 +141,7 @@
       {
         "id": "demo-task-2",
         "name": "Wide-area watch",
-        "description": "Fixed-wing loiter to hold RF relay and broad ISR.",
+        "description": "Fixed-wing loiter to hold RF relay and broad recon.",
         "assignedPlatforms": ["demo-fixedwing"],
         "priority": "Medium",
         "origin_tool": "mission"

--- a/data/sample_parts_library.json
+++ b/data/sample_parts_library.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "1.0.0",
-  "catalogId": "ceradon-sample-001",
+  "catalogId": "sample-cots-001",
   "meta": {
-    "name": "Ceradon Sample COTS Catalog",
+    "name": "Sample COTS Catalog",
     "description": "Sample catalog of commercial off-the-shelf sUAS components for training and demonstration",
     "unit": "Sample Unit",
     "lastUpdated": "2026-01-07T00:00:00Z",
@@ -61,7 +61,7 @@
       "cost_usd": 89.00,
       "availability": "in-stock",
       "notes": "Small fixed-wing platform for extended range missions",
-      "tags": ["fixed-wing", "long-range", "ISR"]
+      "tags": ["fixed-wing", "long-range", "recon"]
     },
     {
       "id": "frame-004",
@@ -399,7 +399,7 @@
       "part_number": "RC-HD-1080",
       "cost_usd": 45.00,
       "availability": "in-stock",
-      "notes": "Lightweight HD camera for ISR",
+      "notes": "Lightweight HD camera for recon",
       "tags": ["camera", "hd", "isr"]
     },
     {

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-This document outlines the implementation strategy for transforming the Ceradon Architect Stack from an orchestration hub into a fully offline-capable, unified mission-planning application for Special Operations Forces.
+This document outlines the implementation strategy for transforming the Ceradon Architect Stack from an orchestration hub into a fully offline-capable, unified mission-planning application for small teams in disconnected environments.
 
 **Current State:** Static hub with links to external tools (NOT offline-capable)
 **Target State:** Complete offline-first application with all planning modules built-in
@@ -12,7 +12,7 @@ This document outlines the implementation strategy for transforming the Ceradon 
 ## I. Critical Architectural Gap
 
 ### Problem Statement
-The current implementation relies on external URLs (ceradonsystems.com) for all planning modules. This violates the core requirement for **zero cloud dependencies** and **offline-first operation** in air-gapped, contested environments.
+The current implementation relies on external URLs for all planning modules. This violates the core requirement for **zero cloud dependencies** and **offline-first operation** in air-gapped, contested environments.
 
 ### Solution Architecture
 Build all planning modules as **local JavaScript applications** that:
@@ -247,7 +247,7 @@ Build all planning modules as **local JavaScript applications** that:
 4. **Version Control**
    - Track template revisions
    - User-submitted improvements
-   - Approval workflow for validated designs
+   - Approval workflow for reviewed designs
    - Change logs
 
 ---

--- a/docs/atak_exports.md
+++ b/docs/atak_exports.md
@@ -30,4 +30,4 @@ The hub can export MissionProject data to two offline-friendly formats meant for
 - Adaptation tip: wrap each unit in your preferred CoT XML/JSON envelope (`a-f-G-U-C` or similar) while retaining the stable IDs.
 
 ## Access control
-These exports do not bypass the access gate; the user must unlock the hub with the stack code before buttons appear. No external API calls are made during export.
+Exports are available in the demo without gating. If you need local access controls, implement them in your deployment environment (browser profile, OS account, or kiosk tooling). No external API calls are made during export.

--- a/docs/mission_project_schema.md
+++ b/docs/mission_project_schema.md
@@ -7,7 +7,7 @@ MissionProject is the neutral JSON contract shared by every Ceradon Architect pl
 | Key | Type | Required | Primary owner | Notes |
 | --- | --- | --- | --- | --- |
 | `schemaVersion` | string | Required | Hub | Semantic version for compatibility checks. Current: `2.0.0`. |
-| `meta` | object | Required | Mission Architect | Name, description, duration, scenario tags, accessCode, and team size/roles. |
+| `meta` | object | Required | Mission Architect | Name, description, duration, scenario tags, and team size/roles. |
 | `mission` | object | Required | Mission Architect | Tasks, phases, assignments, and mission_cards. |
 | `environment` | array | Required | Mission Architect / Node / Mesh | One or more AO contexts (altitudeBand, temperatureBand, terrain, weather). |
 | `constraints` | array | Optional | Mission Architect / Node | Airspace, EW, policy, and power constraints that other tools should preserve. |
@@ -36,7 +36,7 @@ Unknown fields must be preserved when round-tripping between tools.
 
 ### meta (object)
 - `name` (string), `durationHours` (number), `origin_tool` (string).
-- Optional: `description`, `scenario`, `inventoryReference`, `accessCode`, `team{size, roles[]}`.
+- Optional: `description`, `scenario`, `inventoryReference`, `accessCode` (local-only label, unused in demo), `team{size, roles[]}`.
 
 ### mission (object)
 - `tasks[]`: `id`, `name`; optional `description`, `priority`, `assignedPlatforms[]`, `origin_tool`.

--- a/docs/stack_workflows.md
+++ b/docs/stack_workflows.md
@@ -29,10 +29,10 @@ This hub is the connective tissue across Mission Architect, Node Architect, UxS 
 - Warn users when required fields are missing (`meta.name`, `meta.durationHours`, `mission`, `environment[]`).
 - Prefer additive edits—append constraints, add mesh links, or attach kits—without rewriting or renumbering IDs from other tools.
 
-## Links to live tools
+## Links to demo modules
 
-- Mission Architect: https://mission.ceradonsystems.com/
-- Node Architect: https://node.ceradonsystems.com/web/index.html
-- UxS Architect: https://uxs.ceradonsystems.com/web/
-- Mesh Architect: https://mesh.ceradonsystems.com/
-- KitSmith: https://kitsmith.ceradonsystems.com/
+- Mission Planner: https://nbschultz97.github.io/Ceradon-Architect/#/mission
+- Comms Validator: https://nbschultz97.github.io/Ceradon-Architect/#/comms
+- Platform Designer: https://nbschultz97.github.io/Ceradon-Architect/#/platform
+- Parts Library: https://nbschultz97.github.io/Ceradon-Architect/#/library
+- Export: https://nbschultz97.github.io/Ceradon-Architect/#/export

--- a/index.html
+++ b/index.html
@@ -40,9 +40,9 @@
   <!-- Demo Site Notice -->
   <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; padding: 12px 24px; text-align: center; border-bottom: 2px solid #5568d3;">
     <p style="margin: 0; font-size: 14px; font-weight: 500;">
-      🌐 <strong>ONLINE DEMO</strong> — This is a feature demonstration running on GitHub Pages.
-      <span style="opacity: 0.9;">Full offline capability requires production deployment with local assets.</span>
-      <a href="#production-cta" style="color: #fff; text-decoration: underline; margin-left: 12px; font-weight: 600;">Learn More →</a>
+      🌐 <strong>ONLINE DEMO</strong> — Maintained by Noah Schultz (individual).
+      <span style="opacity: 0.9;">Not affiliated with or endorsed by DoD/USG/NPS/SOCPAC/CRUSER.</span>
+      <a href="#demo-disclaimer" style="color: #fff; text-decoration: underline; margin-left: 12px; font-weight: 600;">Details →</a>
     </p>
   </div>
 
@@ -128,9 +128,9 @@
       <div id="production-cta" style="margin: 48px auto; max-width: 900px; background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); border-radius: 12px; padding: 40px; border: 2px solid #667eea; box-shadow: 0 8px 32px rgba(102, 126, 234, 0.2);">
         <div style="text-align: center; margin-bottom: 32px;">
           <p style="margin: 0 0 8px 0; font-size: 14px; text-transform: uppercase; letter-spacing: 2px; color: #667eea; font-weight: 600;">Production Deployment</p>
-          <h2 style="margin: 0 0 16px 0; font-size: 32px; font-weight: 700; color: #fff;">Ready for Air-Gapped Operations?</h2>
+          <h2 style="margin: 0 0 16px 0; font-size: 32px; font-weight: 700; color: #fff;">Ready for Offline Deployment?</h2>
           <p style="margin: 0; font-size: 16px; color: #b8c1ec; line-height: 1.6;">
-            This online demo showcases all features but requires internet connectivity. Deploy the production version on ruggedized, air-gapped systems for true offline capability in contested environments.
+            This online demo showcases all features but requires internet connectivity. For offline use, deploy a local copy with bundled assets and cached data.
           </p>
         </div>
 
@@ -153,7 +153,7 @@
               <li><strong style="color: #4CAF50;">Pre-cached map tiles</strong> for your AO</li>
               <li><strong style="color: #4CAF50;">Load sensitive inventory</strong> via CSV</li>
               <li><strong style="color: #4CAF50;">SRTM elevation tiles</strong> for terrain accuracy</li>
-              <li><strong style="color: #4CAF50;">Air-gap certified</strong> for classified networks</li>
+              <li><strong style="color: #4CAF50;">Offline-first</strong> workflow for disconnected environments</li>
             </ul>
           </div>
         </div>
@@ -166,7 +166,7 @@
 
         <div style="text-align: center;">
           <p style="margin: 0 0 20px 0; font-size: 15px; color: #b8c1ec;">
-            Interested in deploying Ceradon Architect for your unit or organization?
+            Need offline deployment steps? Start with the documentation below.
           </p>
           <div style="display: flex; gap: 16px; justify-content: center; flex-wrap: wrap;">
             <a href="https://github.com/nbschultz97/Ceradon-Architect" target="_blank" style="display: inline-block; padding: 12px 32px; background: #667eea; color: white; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 15px; transition: all 0.3s;">
@@ -174,9 +174,6 @@
             </a>
             <a href="https://github.com/nbschultz97/Ceradon-Architect/blob/main/docs/v0.3_offline_gis_almanac.md" target="_blank" style="display: inline-block; padding: 12px 32px; background: rgba(255, 255, 255, 0.1); color: white; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 15px; border: 2px solid rgba(255, 255, 255, 0.2); transition: all 0.3s;">
               📖 Deployment Docs
-            </a>
-            <a href="mailto:contact@ceradonsystems.com?subject=Ceradon%20Architect%20Production%20Deployment" style="display: inline-block; padding: 12px 32px; background: #4CAF50; color: white; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 15px; transition: all 0.3s;">
-              ✉️ Contact Us
             </a>
           </div>
         </div>
@@ -559,27 +556,27 @@
           </ul>
         </div>
 
-        <!-- Contact -->
+        <!-- Maintainer -->
         <div>
-          <h4 style="margin: 0 0 12px 0; font-size: 16px; font-weight: 600;">Contact</h4>
+          <h4 style="margin: 0 0 12px 0; font-size: 16px; font-weight: 600;">Maintainer</h4>
           <ul style="list-style: none; padding: 0; margin: 0; font-size: 14px;">
             <li style="margin-bottom: 8px;">
-              <a href="mailto:contact@ceradonsystems.com" style="color: var(--text-muted); text-decoration: none;">✉️ Email Us</a>
+              <span style="color: var(--text-muted);">👤 Noah Schultz (individual)</span>
             </li>
             <li style="margin-bottom: 8px;">
-              <a href="https://github.com/nbschultz97" target="_blank" style="color: var(--text-muted); text-decoration: none;">👤 Developer</a>
+              <a href="https://github.com/nbschultz97" target="_blank" style="color: var(--text-muted); text-decoration: none;">GitHub Profile</a>
             </li>
           </ul>
         </div>
       </div>
 
       <!-- Disclaimer -->
-      <div style="border-top: 1px solid var(--border); padding-top: 20px; margin-top: 20px;">
+      <div id="demo-disclaimer" style="border-top: 1px solid var(--border); padding-top: 20px; margin-top: 20px;">
         <p style="margin: 0 0 12px 0; font-size: 13px; color: var(--text-muted); line-height: 1.6;">
-          <strong>Online Demo Disclaimer:</strong> This website demonstrates Ceradon Architect features but requires internet connectivity (Leaflet.js CDN, OpenStreetMap tiles). Production deployments bundle all assets locally for true offline, air-gapped operation. No sensitive data should be entered into this public demo.
+          <strong>Online Demo Disclaimer:</strong> This website demonstrates Ceradon Architect features but requires internet connectivity (Leaflet.js CDN, OpenStreetMap tiles). Production deployments bundle all assets locally for true offline operation. No sensitive data should be entered into this public demo.
         </p>
-        <p style="margin: 0; font-size: 12px; color: var(--text-muted);">
-          © 2026 Ceradon Systems • Open Source • Deployed for evaluation purposes • For production deployment inquiries, contact <a href="mailto:contact@ceradonsystems.com" style="color: var(--accent); text-decoration: none;">contact@ceradonsystems.com</a>
+        <p style="margin: 0; font-size: 12px; color: var(--text-muted); line-height: 1.6;">
+          Maintained by Noah Schultz (individual). Not affiliated with or endorsed by DoD/USG/NPS/SOCPAC/CRUSER. Open-source demo with example data only. No agency relationship implied.
         </p>
       </div>
     </div>

--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
   "offline": {
-    "version": "0.4.0-alpha.1",
+    "version": "0.4.0-alpha.2",
     "stage": "alpha",
-    "released": "2026-01-08",
+    "released": "2026-01-09",
     "description": "Offline mission planning tool for air-gapped environments - Digital Construction Foreman",
     "features": {
       "partsLibrary": {
@@ -41,7 +41,7 @@
       "platforms": ["Windows", "macOS", "Linux"]
     },
     "nextMilestone": {
-      "version": "0.4.0-alpha.1",
+      "version": "0.4.0-alpha.2",
       "targetDate": "2026-02-01",
       "goals": [
         "Comprehensive error handling",
@@ -54,13 +54,13 @@
     "targetRelease": "2026-Q3"
   },
   "webPlayground": {
-    "version": "0.4.0-alpha.1",
+    "version": "0.4.0-alpha.2",
     "stage": "alpha",
-    "released": "2026-01-08",
+    "released": "2026-01-09",
     "description": "Interactive web demo mirroring offline tool functionality",
-    "url": "https://architect.ceradonsystems.com",
-    "purpose": "Marketing and demonstration - ALWAYS mirrors offline version",
-    "syncedWith": "offline:0.4.0-alpha.1",
+    "url": "https://nbschultz97.github.io/Ceradon-Architect/",
+    "purpose": "Public demo only; always mirrors offline version",
+    "syncedWith": "offline:0.4.0-alpha.2",
     "features": {
       "allModules": "functional",
       "sampleData": "included",


### PR DESCRIPTION
### Motivation

- Convert the repository to a defensible, individually-maintained open-source project with clear governance and legal hygiene.  
- Remove company-owned contact/funnel language and any implied endorsement or operational claims from the public demo and docs.  
- Move demo posture to the GitHub Pages default domain and document simple deployment steps.  
- Make the demo clearly example-only and ensure sample data and gating defaults are neutral and generic.

### Description

- Added governance and hygiene artifacts: `LICENSE` (Apache-2.0), `GOVERNANCE.md`, `CONTRIBUTING.md`, `SECURITY.md`, and `DISCLAIMER.md`.  
- Neutralized UI and docs: updated `README.md`, `index.html` banner/footer, removed company email links, removed `CNAME`, and pointed demos to the GitHub Pages default URL (`https://nbschultz97.github.io/Ceradon-Architect/`).  
- Cleaned demo/data/gating: cleared the default `accessCode` in `assets/js/mission_project.js`, removed `accessCode` from `data/demo_mission_project.json`, updated sample catalog identifiers and example labels (recon wording), and clarified exports are ungated in docs.  
- Versioning and metadata updates: bumped app/version to `0.4.0-alpha.2` in `assets/js/app.js` and `version.json`, added `CHANGELOG.md` entry for the release, and reframed `SECURITY_AUDIT_v0.3.md` as a non-certifying self-review.

### Testing

- Performed an automated local smoke-render using a headless browser to load the served site and captured a screenshot to verify banner/footer and home page render, and it succeeded.  
- No unit test suite was added or executed as part of this change.  
- Static content changes only; the documented local run command is `python -m http.server 8000` to verify the demo locally.  
- No CI integration or automated security scanning was run in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69604a8e1bec8328a9e885846c9e556c)