### PR TITLE
Graceful map fallback when Leaflet missing and update demo links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nothing yet
 
 ### Web Playground
-- Nothing yet
+- Fixed map viewer boot to degrade gracefully when Leaflet fails to load, avoiding a blank page on the demo.
+- Updated demo footer resource links to point at the current repository for accurate changelog and docs access.
 
 ---
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2911,7 +2911,13 @@ function initMapViewer() {
         onLocationSelect: handleMapLocationSelect
       });
 
-      console.log('[MapViewer] Map initialized successfully');
+      if (!mapViewerInstance) {
+        if (typeof UIFeedback !== 'undefined') {
+          UIFeedback.Toast.warning('Map viewer unavailable. Leaflet did not load.', 5000);
+        }
+      } else {
+        console.log('[MapViewer] Map initialized successfully');
+      }
     } catch (error) {
       console.error('[MapViewer] Failed to initialize map:', error);
       return;

--- a/assets/js/map_viewer.js
+++ b/assets/js/map_viewer.js
@@ -26,6 +26,21 @@ const MapViewer = (() => {
       return null;
     }
 
+    if (typeof window.L === 'undefined') {
+      console.error('[MapViewer] Leaflet dependency not loaded. Map viewer disabled.');
+      container.innerHTML = `
+        <div style="display: grid; place-items: center; text-align: center; padding: 24px; height: 100%; color: #ff9800;">
+          <div>
+            <p style="margin: 0 0 8px 0; font-weight: 600;">Map viewer unavailable</p>
+            <p style="margin: 0; font-size: 13px; color: var(--text-muted);">
+              Leaflet failed to load. Confirm the demo has internet access or bundle Leaflet for offline use.
+            </p>
+          </div>
+        </div>
+      `;
+      return null;
+    }
+
     // Load last viewed location or use default
     const lastLocation = loadLastLocation() || DEFAULT_CENTER;
     const center = options.center || lastLocation;

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
             <p class="small" style="margin: 0 0 12px 0;">
               This online demo requires internet. For air-gapped operation with auto-save sessions, build the desktop installer.
             </p>
-            <a class="btn primary" href="https://github.com/nbschultz97/COTS-Architect#desktop-app-windows" target="_blank" style="text-decoration: none;">
+            <a class="btn primary" href="https://github.com/nbschultz97/Ceradon-Architect#desktop-app-windows" target="_blank" style="text-decoration: none;">
               📥 Get Desktop Version (Windows)
             </a>
           </div>
@@ -776,19 +776,19 @@
           <h4 style="margin: 0 0 12px 0; font-size: 16px; font-weight: 600;">Resources</h4>
           <ul style="list-style: none; padding: 0; margin: 0; font-size: 14px;">
             <li style="margin-bottom: 8px;">
-              <a href="https://github.com/nbschultz97/COTS-Architect" target="_blank" style="color: var(--text-muted); text-decoration: none;">GitHub Repository</a>
+              <a href="https://github.com/nbschultz97/Ceradon-Architect" target="_blank" style="color: var(--text-muted); text-decoration: none;">GitHub Repository</a>
             </li>
             <li style="margin-bottom: 8px;">
-              <a href="https://github.com/nbschultz97/COTS-Architect/blob/main/CHANGELOG.md" target="_blank" style="color: var(--text-muted); text-decoration: none;">📋 Changelog & Updates</a>
+              <a href="https://github.com/nbschultz97/Ceradon-Architect/blob/main/CHANGELOG.md" target="_blank" style="color: var(--text-muted); text-decoration: none;">📋 Changelog & Updates</a>
             </li>
             <li style="margin-bottom: 8px;">
-              <a href="https://github.com/nbschultz97/COTS-Architect/blob/main/docs/v0.3_offline_gis_almanac.md" target="_blank" style="color: var(--text-muted); text-decoration: none;">Documentation</a>
+              <a href="https://github.com/nbschultz97/Ceradon-Architect/blob/main/docs/v0.3_offline_gis_almanac.md" target="_blank" style="color: var(--text-muted); text-decoration: none;">Documentation</a>
             </li>
             <li style="margin-bottom: 8px;">
-              <a href="https://github.com/nbschultz97/COTS-Architect/blob/main/SECURITY_AUDIT_v0.3.md" target="_blank" style="color: var(--text-muted); text-decoration: none;">Security Audit</a>
+              <a href="https://github.com/nbschultz97/Ceradon-Architect/blob/main/SECURITY_AUDIT_v0.3.md" target="_blank" style="color: var(--text-muted); text-decoration: none;">Security Audit</a>
             </li>
             <li style="margin-bottom: 8px;">
-              <a href="https://github.com/nbschultz97/COTS-Architect/issues" target="_blank" style="color: var(--text-muted); text-decoration: none;">Report Issues</a>
+              <a href="https://github.com/nbschultz97/Ceradon-Architect/issues" target="_blank" style="color: var(--text-muted); text-decoration: none;">Report Issues</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
### Motivation
- The demo site could break or show a blank area when the Leaflet CDN failed to load, so the map module must degrade gracefully for air-gapped or offline operation. 
- Footer/CTA links in the demo pointed to an alternate repo name and needed to be consistent with the repository in this workspace.

### Description
- Added a runtime guard in `assets/js/map_viewer.js` that checks `window.L` and, if Leaflet is missing, renders a user-facing placeholder and logs an error so the page doesn't break. 
- Updated `assets/js/app.js` to emit a UI warning via `UIFeedback.Toast` when the map fails to initialize, and to only log success when a map instance is actually created. 
- Updated `index.html` CTA/footer links to reference the current repository (`Ceradon-Architect`) instead of the previously used `COTS-Architect`. 
- Recorded the change in `CHANGELOG.md` under the `Unreleased` section noting the map fallback and updated demo links.

### Testing
- Performed a local smoke test by serving the site with `python -m http.server` and using Playwright to load the home page with `wait_until: networkidle`, successfully capturing a full-page screenshot which demonstrates the page renders and the map region no longer breaks. 
- No unit tests were run; changes are small, front-end fallbacks and copy updates only, and behaved as expected in the smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966eb720ac08328b4d333681c534122)